### PR TITLE
Read report

### DIFF
--- a/cvm-attestation/AttestationClient.py
+++ b/cvm-attestation/AttestationClient.py
@@ -320,7 +320,8 @@ class AttestationClient():
       return hw_report
     except Exception as e:
       self.log.error(f"Error while reading hardware report. Exception {e}")
-  
+
+
   def log_snp_report(self, hw_report):
     """
     Logs snp snp attestation report fields.
@@ -330,15 +331,15 @@ class AttestationClient():
     self.log.info(f"Report version: {report_instance.version}")
     self.log.info(f"Report guest svn: {report_instance.guest_svn}")
 
-    formatted_tcb = "".join(f"{byte:02X}" for byte in report_instance.current_tcb.serialize())
+    formatted_tcb = "".join(f"{byte:02X}" for byte in report_instance.current_tcb.serialize()[::-1])
     self.log.info(f"Current TCB version: {formatted_tcb}")
 
-    formatted_tcb = "".join(f"{byte:02X}" for byte in report_instance.reported_tcb.serialize())
+    formatted_tcb = "".join(f"{byte:02X}" for byte in report_instance.reported_tcb.serialize()[::-1])
     self.log.info(f"Reported TCB version: {formatted_tcb}")
 
-    formatted_tcb = "".join(f"{byte:02X}" for byte in report_instance.committed_tcb.serialize())
+    formatted_tcb = "".join(f"{byte:02X}" for byte in report_instance.committed_tcb.serialize()[::-1])
     self.log.info(f"Commited TCB version: {formatted_tcb}")
 
-    formatted_tcb = "".join(f"{byte:02X}" for byte in report_instance.launch_tcb.serialize())
+    formatted_tcb = "".join(f"{byte:02X}" for byte in report_instance.launch_tcb.serialize()[::-1])
     self.log.info(f"Launched TCB version: {formatted_tcb}")
 

--- a/cvm-attestation/AttestationClient.py
+++ b/cvm-attestation/AttestationClient.py
@@ -89,10 +89,10 @@ class AttestationClient():
     self.log = logger
 
     self.provider = MAAProvider(logger,isolation_type,endpoint) if verifier == Verifier.MAA else ITAProvider(logger,isolation_type,endpoint, api_key) if verifier == Verifier.ITA else None
-  
+
   def attest_guest(self):
     """
-    Attest the Guest
+    Attest the Hardware and Guest
     """
 
     # Attest the platform using exponential backoff
@@ -216,6 +216,7 @@ class AttestationClient():
 
   def attest_platform(self):
     """
+    Attest the Hardware
     """
 
     # Attest the platform using exponential backoff
@@ -289,25 +290,16 @@ class AttestationClient():
             f"Request failed after all retries have been exhausted. Error: {e}"
           )
 
-
   def get_hardware_report(self):
     try:
-      self.log.info('Attesting Platform Evidence...')
+      self.log.info('Fetching hardware report...')
 
       tss_wrapper = TssWrapper(self.log)
-      isolation_type = self.parameters.isolation_type
       # Extract Hardware Report and Runtime Data
       hcl_report = tss_wrapper.get_hcl_report(self.parameters.user_claims)
       report_type = ReportParser.extract_report_type(hcl_report)
-      # runtime_data = ReportParser.extract_runtimes_data(hcl_report)
       hw_report = ReportParser.extract_hw_report(hcl_report)
 
       return hw_report
-      # if report_type == 'tdx' and isolation_type == IsolationType.TDX:
-      #   # encoded_hw_evidence = imds_client.get_td_quote(encoded_report)
-      # elif report_type == 'snp' and isolation_type == IsolationType.SEV_SNP:
-      #   # ad
-      # else:
-
     except Exception as e:
       self.log.error(f"Error while reading hardware report. Exception {e}")

--- a/cvm-attestation/AttestationClient.py
+++ b/cvm-attestation/AttestationClient.py
@@ -288,3 +288,26 @@ class AttestationClient():
           self.log.error(
             f"Request failed after all retries have been exhausted. Error: {e}"
           )
+
+
+  def get_hardware_report(self):
+    try:
+      self.log.info('Attesting Platform Evidence...')
+
+      tss_wrapper = TssWrapper(self.log)
+      isolation_type = self.parameters.isolation_type
+      # Extract Hardware Report and Runtime Data
+      hcl_report = tss_wrapper.get_hcl_report(self.parameters.user_claims)
+      report_type = ReportParser.extract_report_type(hcl_report)
+      # runtime_data = ReportParser.extract_runtimes_data(hcl_report)
+      hw_report = ReportParser.extract_hw_report(hcl_report)
+
+      return hw_report
+      # if report_type == 'tdx' and isolation_type == IsolationType.TDX:
+      #   # encoded_hw_evidence = imds_client.get_td_quote(encoded_report)
+      # elif report_type == 'snp' and isolation_type == IsolationType.SEV_SNP:
+      #   # ad
+      # else:
+
+    except Exception as e:
+      self.log.error(f"Error while reading hardware report. Exception {e}")

--- a/cvm-attestation/README.md
+++ b/cvm-attestation/README.md
@@ -1,6 +1,10 @@
 # Python Attestation Sample App
 Remote Attestation empowers a `relying party`, whether it be the workload owner or the user, to authenticate that their workload is operating on a platform equipped with `Intel TDX` technology before divulging sensitive information. In this instance, we undertake the assessment of the `Hardware Report's` integrity and trustworthiness through the services of an Attestation Provider. This application serves as an instructive demonstration highlighting the implementation of Remote Attestation using Python programming language.
 
+## Tools
+- [Attestation Tool](#attest)
+- [Rading Hardware Report Tool](#read_report-only-snp)
+
 ## Overview
 
 ![Attestation](img/attest.png)
@@ -17,41 +21,50 @@ For uninstalling the cli tool run the following command:
 pip3 uninstall attest -y
 ```
 
-## Run CLI Tool
+## Uninstall the `read_report` CLI Tool
+For uninstalling the cli tool run the following command:
+```
+pip3 uninstall read_report -y
+```
 
-### `--c` Config File Option
+## attest
+Tool to attest the CVM
+
+### Run CLI Tool
+
+#### `--c` Config File Option
 Option to set config file
 ```
 sudo attest  --c config_sample.json
 ```
 
-### `--t` Attestation Type Option
+#### `--t` Attestation Type Option
 Option to provide type of attestation to be run
 
-#### Platform
+##### Platform
 Attest the Hardware using the Machines Hardware Report
 ```
 sudo attest  --c config_sample.json --t Platform
 ```
 
-#### Guest
+##### Guest
 Attest the Hardware and the Guest measurements
 ```
 sudo attest  --c config_sample.json --t Guest
 ```
 > NOTE: Attesting the Guest is only supported in SEV-SNP CVM
 
-### SNP (MAA Only)
+#### SNP (MAA Only)
 ```
 sudo attest  --c config_snp.json
 ```
 
-### TDX with MAA
+#### TDX with MAA
 ```
 sudo attest  --c config_tdx.json
 ```
 
-### TDX with Intel Trust Authority
+#### TDX with Intel Trust Authority
 ```
 sudo attest  --c config_tdx_ita.json
 ```
@@ -60,8 +73,8 @@ sudo attest  --c config_tdx_ita.json
 
 The console output will contain the `Token` returned by the Attestation Provider as well as some of the claims parsed from the token.
 
-## TDX 
-### Attesting with MAA
+### TDX 
+#### Attesting with MAA
 ```
 Attested Platform Successfully!!
 
@@ -78,7 +91,7 @@ CVM Configuration:
         TPM Persisted:  False
 ```
 
-### Attesting with Intel Trust Authority
+#### Attesting with Intel Trust Authority
 ```
 Attested Platform Successfully!!
 
@@ -88,8 +101,8 @@ Claims:
         Evidence Type:  TDX
 ```
 
-## SEV-SNP
-### Attesting with MAA
+### SEV-SNP
+#### Attesting with MAA
 ```
 Attested Platform Successfully!!
 
@@ -105,4 +118,22 @@ CVM Configuration:
         Secure Boot Enabled:  True
         TPM Enabled:  True
         User Data:  00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
+```
+
+## read_report (only SNP)
+Tool to read the Attestation report from the hardware the CVM is running on.
+
+### Run CLI Tool
+
+#### `--t` or `-type` Attestation Type (optional)
+Option to provide type of attestation to be run.
+```
+sudo read_report  --t snp_report
+```
+
+
+#### `--o` or `-out` Output filename (optional)
+The name of the output file to store the report
+```
+sudo read_report  --o report.bin
 ```

--- a/cvm-attestation/attest.py
+++ b/cvm-attestation/attest.py
@@ -49,8 +49,8 @@ def attest(c, t, r):
   logger.info("Attestation started...")
   logger.info(c)
 
-  # try:
   attestation_type = t
+  file_path = 'report.bin'
 
   # creates an attestation parameters based on user's config
   config_json = parse_config_file(c)
@@ -65,12 +65,12 @@ def attest(c, t, r):
 
   # Attest based on user configuration
   attestation_client = AttestationClient(logger, client_parameters)
+  hw_report = attestation_client.get_hardware_report()
 
-  # Read hardware report and dumps the binary into a file
-  if r:
-    logger.info('Reading hardware report...')
-    # attestation_client.get_hardware_report()
-    # attestation_client.get_hw_report()
+  # Store hardware report
+  with open(file_path, 'wb') as file:
+    file.write(hw_report)
+  logger.info(f"Output successfully written to: {file_path}")
 
   parsed_endpoint = urlparse(endpoint)
   if not parsed_endpoint.scheme or not parsed_endpoint.netloc:

--- a/cvm-attestation/attest.py
+++ b/cvm-attestation/attest.py
@@ -36,14 +36,19 @@ class AttestException(Exception):
   pass
 
 @click.command()
-@click.option('--c', type=str, help = 'Config json file')
+@click.option(
+  '--c',
+  type=str,
+  required=True,
+  help = 'Config json file',
+)
 @click.option(
   '--t',
   type=click.Choice(['Guest', 'Platform'], case_sensitive=False),
   default='Platform',
   help='Attestation type: Guest or Platform (Default)'
 )
-def attest(c, t, r):
+def attest(c, t):
   # create a new console logger
   logger = Logger('logger').get_logger()
   logger.info("Attestation started...")

--- a/cvm-attestation/attest.py
+++ b/cvm-attestation/attest.py
@@ -38,7 +38,8 @@ class AttestException(Exception):
 @click.command()
 @click.option('--c', type=str, help = 'Config json file')
 @click.option('--t', type=click.Choice(['Guest', 'Platform'], case_sensitive=False), default='Platform', help='Attestation type: Guest or Platform (Default)')
-def attest(c, t):
+@click.option('--r', '-read', type=click.Choice(['snp_report', 'td_quote'], case_sensitive=True), default='snp_report', help='Dump hardware report: td_quote or snp_report (Default)')
+def attest(c, t, r):
   # create a new console logger
   logger = Logger('logger').get_logger()
   logger.info("Attestation started...")
@@ -60,6 +61,12 @@ def attest(c, t):
 
   # Attest based on user configuration
   attestation_client = AttestationClient(logger, client_parameters)
+
+  # Read hardware report and dumps the binary into a file
+  if r:
+    logger.info('Reading hardware report...')
+    # attestation_client.get_hardware_report()
+    # attestation_client.get_hw_report()
 
   parsed_endpoint = urlparse(endpoint)
   if not parsed_endpoint.scheme or not parsed_endpoint.netloc:

--- a/cvm-attestation/attest.py
+++ b/cvm-attestation/attest.py
@@ -37,8 +37,12 @@ class AttestException(Exception):
 
 @click.command()
 @click.option('--c', type=str, help = 'Config json file')
-@click.option('--t', type=click.Choice(['Guest', 'Platform'], case_sensitive=False), default='Platform', help='Attestation type: Guest or Platform (Default)')
-@click.option('--r', '-read', type=click.Choice(['snp_report', 'td_quote'], case_sensitive=True), default='snp_report', help='Dump hardware report: td_quote or snp_report (Default)')
+@click.option(
+  '--t',
+  type=click.Choice(['Guest', 'Platform'], case_sensitive=False),
+  default='Platform',
+  help='Attestation type: Guest or Platform (Default)'
+)
 def attest(c, t, r):
   # create a new console logger
   logger = Logger('logger').get_logger()

--- a/cvm-attestation/read_report.py
+++ b/cvm-attestation/read_report.py
@@ -1,0 +1,79 @@
+import click
+from AttestationClient import AttestationClient
+from src.Logger import Logger
+from snp import SNP_VM_REPORT
+
+
+@click.command()
+@click.option(
+    '--t', '-type',
+    type=click.Choice(['snp_report', 'td_quote'], case_sensitive=True),
+    required=True,
+    help='Specify the type of hardware report to dump: snp_report or td_quote.'
+)
+@click.option(
+    '--o', '-out',
+    type=click.Path(writable=True, dir_okay=False),
+    required=False,
+    help='Specify the file path to store the output (optional).'
+)
+def read_report(t, o):
+    """
+    CLI tool to read and optionally save hardware reports.
+    """
+    logger = setup_logger()
+
+    logger.info("Attestation started...")
+    logger.info(f"Report type selected: {t}")
+
+    # Initialize attestation client
+    attestation_client = AttestationClient(logger)
+
+    # Handle the hardware report
+    handle_hardware_report(t, o, attestation_client)
+
+
+def setup_logger():
+    """
+    Set up and return a logger instance.
+    """
+    return Logger('logger').get_logger()
+
+
+def handle_hardware_report(report_type, output_path, attestation_client):
+    """
+    Handle the hardware report generation and optional saving.
+    """
+    logger = attestation_client.log
+    logger.info(f"Reading hardware report: {report_type}")
+
+    if report_type == 'snp_report':
+        # Retrieve and deserialize the SNP report
+        report_binary = attestation_client.get_hardware_report()
+        report = SNP_VM_REPORT.deserialize(report_binary)
+
+        # Display the report
+        report.display()
+
+        # Optionally save the report to a file
+        if output_path:
+            save_to_file(output_path, report_binary)
+            logger.info(f"Report saved to: {output_path}")
+
+    elif report_type == 'td_quote':
+        logger.info("TD Quote report option is not implemented yet.")
+    else:
+        raise ValueError(f"Invalid hardware report type: {report_type}")
+
+
+def save_to_file(file_path, content):
+    """
+    Save binary content to the specified file path.
+    """
+    with open(file_path, 'wb') as file:
+        file.write(content)
+    print(f"Output successfully written to: {file_path}")
+
+
+if __name__ == "__main__":
+  read_report()

--- a/cvm-attestation/read_report.py
+++ b/cvm-attestation/read_report.py
@@ -2,7 +2,7 @@ import click
 from AttestationClient import AttestationClient, AttestationClientParameters, Verifier
 from src.Isolation import IsolationType
 from src.Logger import Logger
-from snp import SNP_VM_REPORT
+from snp import AttestationReport
 
 
 DEFAULT_ENDPOINT = 'https://sharedweu.weu.attest.azure.net/attest/SevSnpVm?api-version=2022-08-01'
@@ -11,7 +11,7 @@ DEFAULT_ENDPOINT = 'https://sharedweu.weu.attest.azure.net/attest/SevSnpVm?api-v
 @click.option(
   '--t', '-type',
   type=click.Choice(['snp_report', 'td_quote'], case_sensitive=True),
-  required=True,
+  default='snp_report',
   help='Specify the type of hardware report to dump: snp_report or td_quote.'
 )
 @click.option(
@@ -52,16 +52,20 @@ def handle_hardware_report(report_type, output_path, attestation_client):
   if report_type == 'snp_report':
     # Retrieve and deserialize the SNP report
     report_binary = attestation_client.get_hardware_report()
-    report = SNP_VM_REPORT.deserialize(report_binary)
+    report = AttestationReport.deserialize(report_binary)
 
     # Display the report
     report.display()
 
+    filename = 'report.bin'
     # Optionally save the report to a file
     if output_path:
-      save_to_file(output_path, report_binary)
-      logger.info(f"Report saved to: {output_path}")
+      filename = output_path
 
+    save_to_file(filename, report_binary)
+    logger.info(f"Report saved to: {filename}")
+
+    logger.info("Got attestation report successfully!")
   elif report_type == 'td_quote':
     logger.info("TD Quote report option is not implemented yet.")
   else:

--- a/cvm-attestation/read_report.py
+++ b/cvm-attestation/read_report.py
@@ -1,78 +1,80 @@
 import click
-from AttestationClient import AttestationClient
+from AttestationClient import AttestationClient, AttestationClientParameters, Verifier
+from src.Isolation import IsolationType
 from src.Logger import Logger
 from snp import SNP_VM_REPORT
 
 
+DEFAULT_ENDPOINT = 'https://sharedweu.weu.attest.azure.net/attest/SevSnpVm?api-version=2022-08-01'
+
 @click.command()
 @click.option(
-    '--t', '-type',
-    type=click.Choice(['snp_report', 'td_quote'], case_sensitive=True),
-    required=True,
-    help='Specify the type of hardware report to dump: snp_report or td_quote.'
+  '--t', '-type',
+  type=click.Choice(['snp_report', 'td_quote'], case_sensitive=True),
+  required=True,
+  help='Specify the type of hardware report to dump: snp_report or td_quote.'
 )
 @click.option(
-    '--o', '-out',
-    type=click.Path(writable=True, dir_okay=False),
-    required=False,
-    help='Specify the file path to store the output (optional).'
+  '--o', '-out',
+  type=click.Path(writable=True, dir_okay=False),
+  required=False,
+  help='Specify the file path to store the output (optional).'
 )
 def read_report(t, o):
-    """
-    CLI tool to read and optionally save hardware reports.
-    """
-    logger = setup_logger()
+  """
+  CLI tool to read and optionally save hardware reports.
+  """
+  logger = Logger('logger').get_logger()
 
-    logger.info("Attestation started...")
-    logger.info(f"Report type selected: {t}")
+  logger.info("Attestation started...")
+  logger.info(f"Report type selected: {t}")
 
-    # Initialize attestation client
-    attestation_client = AttestationClient(logger)
+  # Initialize attestation client
+  client_parameters = AttestationClientParameters(
+    DEFAULT_ENDPOINT,
+    Verifier.MAA,
+    IsolationType.SEV_SNP,
+    ''
+  )
+  attestation_client = AttestationClient(logger, client_parameters)
 
-    # Handle the hardware report
-    handle_hardware_report(t, o, attestation_client)
-
-
-def setup_logger():
-    """
-    Set up and return a logger instance.
-    """
-    return Logger('logger').get_logger()
+  # Handle the hardware report
+  handle_hardware_report(t, o, attestation_client)
 
 
 def handle_hardware_report(report_type, output_path, attestation_client):
-    """
-    Handle the hardware report generation and optional saving.
-    """
-    logger = attestation_client.log
-    logger.info(f"Reading hardware report: {report_type}")
+  """
+  Handle the hardware report generation and optional saving.
+  """
+  logger = attestation_client.log
+  logger.info(f"Reading hardware report: {report_type}")
 
-    if report_type == 'snp_report':
-        # Retrieve and deserialize the SNP report
-        report_binary = attestation_client.get_hardware_report()
-        report = SNP_VM_REPORT.deserialize(report_binary)
+  if report_type == 'snp_report':
+    # Retrieve and deserialize the SNP report
+    report_binary = attestation_client.get_hardware_report()
+    report = SNP_VM_REPORT.deserialize(report_binary)
 
-        # Display the report
-        report.display()
+    # Display the report
+    report.display()
 
-        # Optionally save the report to a file
-        if output_path:
-            save_to_file(output_path, report_binary)
-            logger.info(f"Report saved to: {output_path}")
+    # Optionally save the report to a file
+    if output_path:
+      save_to_file(output_path, report_binary)
+      logger.info(f"Report saved to: {output_path}")
 
     elif report_type == 'td_quote':
-        logger.info("TD Quote report option is not implemented yet.")
+      logger.info("TD Quote report option is not implemented yet.")
     else:
-        raise ValueError(f"Invalid hardware report type: {report_type}")
+      raise ValueError(f"Invalid hardware report type: {report_type}")
 
 
 def save_to_file(file_path, content):
-    """
-    Save binary content to the specified file path.
-    """
-    with open(file_path, 'wb') as file:
-        file.write(content)
-    print(f"Output successfully written to: {file_path}")
+  """
+  Save binary content to the specified file path.
+  """
+  with open(file_path, 'wb') as file:
+    file.write(content)
+  print(f"Output successfully written to: {file_path}")
 
 
 if __name__ == "__main__":

--- a/cvm-attestation/read_report.py
+++ b/cvm-attestation/read_report.py
@@ -62,10 +62,10 @@ def handle_hardware_report(report_type, output_path, attestation_client):
       save_to_file(output_path, report_binary)
       logger.info(f"Report saved to: {output_path}")
 
-    elif report_type == 'td_quote':
-      logger.info("TD Quote report option is not implemented yet.")
-    else:
-      raise ValueError(f"Invalid hardware report type: {report_type}")
+  elif report_type == 'td_quote':
+    logger.info("TD Quote report option is not implemented yet.")
+  else:
+    raise ValueError(f"Invalid hardware report type: {report_type}")
 
 
 def save_to_file(file_path, content):

--- a/cvm-attestation/read_report.py
+++ b/cvm-attestation/read_report.py
@@ -62,7 +62,8 @@ def handle_hardware_report(report_type, output_path, attestation_client):
     if output_path:
       filename = output_path
 
-    save_to_file(filename, report_binary)
+    with open(filename, 'wb') as file:
+      file.write(report_binary)
     logger.info(f"Report saved to: {filename}")
 
     logger.info("Got attestation report successfully!")
@@ -70,15 +71,6 @@ def handle_hardware_report(report_type, output_path, attestation_client):
     logger.info("TD Quote report option is not implemented yet.")
   else:
     raise ValueError(f"Invalid hardware report type: {report_type}")
-
-
-def save_to_file(file_path, content):
-  """
-  Save binary content to the specified file path.
-  """
-  with open(file_path, 'wb') as file:
-    file.write(content)
-  print(f"Output successfully written to: {file_path}")
 
 
 if __name__ == "__main__":

--- a/cvm-attestation/setup.py
+++ b/cvm-attestation/setup.py
@@ -9,13 +9,14 @@ setup(
     name='attest',
     version='0.1',
     packages=find_packages(),
-    py_modules=['attest', 'tpm_wrapper', 'AttestationClient', 'AttestationTypes', 'snp.py'],  # Include the attest module
+    py_modules=['attest', 'tpm_wrapper', 'AttestationClient', 'AttestationTypes', 'read_report', 'snp'],  # Include the attest module
     install_requires=[
         'Click',
     ],
     entry_points={
         'console_scripts': [
             'attest = attest:attest',
+            'read_report=read_report:read_report',
         ],
     }
 )

--- a/cvm-attestation/setup.py
+++ b/cvm-attestation/setup.py
@@ -9,7 +9,7 @@ setup(
     name='attest',
     version='0.1',
     packages=find_packages(),
-    py_modules=['attest', 'tpm_wrapper', 'AttestationClient', 'AttestationTypes'],  # Include the attest module
+    py_modules=['attest', 'tpm_wrapper', 'AttestationClient', 'AttestationTypes', 'snp.py'],  # Include the attest module
     install_requires=[
         'Click',
     ],

--- a/cvm-attestation/snp.py
+++ b/cvm-attestation/snp.py
@@ -1,0 +1,407 @@
+import struct
+from typing import List
+
+
+class SNP_SIGNATURE:
+    def __init__(self, r_component=None, s_component=None, reserved=None):
+        self.r_component = r_component or [0] * 72  # RComponent[72]
+        self.s_component = s_component or [0] * 72  # SComponent[72]
+        self.reserved = reserved or [0] * 368       # RSVD[368]
+
+    def serialize(self):
+        return struct.pack(
+            '<72s72s368s',
+            bytes(self.r_component),
+            bytes(self.s_component),
+            bytes(self.reserved)
+        )
+
+    @classmethod
+    def deserialize(cls, data):
+        unpacked_data = struct.unpack('<72s72s368s', data)
+        return cls(
+            list(unpacked_data[0]),
+            list(unpacked_data[1]),
+            list(unpacked_data[2])
+        )
+
+
+class SNP_SVN:
+    def __init__(self, bootloader=0, tee=0, reserved=0, snp=0, microcode=0):
+        self.bootloader = bootloader
+        self.tee = tee
+        self.reserved = reserved
+        self.snp = snp
+        self.microcode = microcode
+
+    def serialize(self):
+        return struct.pack(
+            '>Q',
+            (self.microcode << 56)
+            | (self.snp << 48)
+            | (self.reserved << 16)
+            | (self.tee << 8)
+            | self.bootloader
+        )
+
+    @classmethod
+    def deserialize(cls, data):
+        unpacked_data = struct.unpack('<Q', data)[0]
+        return cls(
+            bootloader=unpacked_data & 0xFF,
+            tee=(unpacked_data >> 8) & 0xFF,
+            reserved=(unpacked_data >> 16) & 0xFFFFFFFF,
+            snp=(unpacked_data >> 48) & 0xFF,
+            microcode=(unpacked_data >> 56) & 0xFF
+        )
+
+class PlatformInfo:
+    def __init__(self, smt_enabled=0, tsme_enabled=0, ecc_enabled=0, rapl_disabled=0, ciphertext_hiding_enabled=0, reserved=0):
+        self.smt_enabled = smt_enabled
+        self.tsme_enabled = tsme_enabled
+        self.ecc_enabled = ecc_enabled
+        self.rapl_disabled = rapl_disabled
+        self.ciphertext_hiding_enabled = ciphertext_hiding_enabled
+        self.reserved = reserved
+
+    def serialize(self):
+        return (
+            (self.reserved << 5)
+            | (self.ciphertext_hiding_enabled << 4)
+            | (self.rapl_disabled << 3)
+            | (self.ecc_enabled << 2)
+            | (self.tsme_enabled << 1)
+            | self.smt_enabled
+        )
+
+    @classmethod
+    def deserialize(cls, data):
+        unpacked_data = struct.unpack('<Q', data)[0]  # Assuming it's a uint64_t
+        return cls(
+            smt_enabled=unpacked_data & 0x1,
+            tsme_enabled=(unpacked_data >> 1) & 0x1,
+            ecc_enabled=(unpacked_data >> 2) & 0x1,
+            rapl_disabled=(unpacked_data >> 3) & 0x1,
+            ciphertext_hiding_enabled=(unpacked_data >> 4) & 0x1,
+            reserved=(unpacked_data >> 5) & ((1 << 59) - 1)  # Mask bits 5 to 63
+        )
+
+
+class KeyInfo:
+    def __init__(self, author_key_en=0, mask_chip_key=0, signing_key=0, reserved=0):
+        """
+        Initialize the KeyInfo structure.
+        """
+        self.author_key_en = author_key_en      # Bit 0
+        self.mask_chip_key = mask_chip_key      # Bit 1
+        self.signing_key = signing_key          # Bits 2–4
+        self.reserved = reserved                # Bits 5–31
+
+    def serialize(self):
+        """
+        Serialize the KeyInfo structure into a 4-byte little-endian integer.
+        """
+        return struct.pack(
+            '<I',
+            (self.reserved << 5) |
+            (self.signing_key << 2) |
+            (self.mask_chip_key << 1) |
+            self.author_key_en
+        )
+
+    @classmethod
+    def deserialize(cls, data):
+        """
+        Deserialize a 4-byte little-endian integer into a KeyInfo instance.
+        """
+        value = struct.unpack('<I', data)[0]
+        return cls(
+            author_key_en=value & 0x1,
+            mask_chip_key=(value >> 1) & 0x1,
+            signing_key=(value >> 2) & 0x7,
+            reserved=(value >> 5) & 0x7FFFFFF
+        )
+
+
+
+class SNP_VM_REPORT:
+    # Define the structure's format string as a class-level constant
+    FORMAT_STRING = (
+        '<IIQ16s16sII'  # version, guest_svn, policy, family_id, image_id, vmpl, sig_algo
+        'Q'             # current_tcb (8 bytes)
+        'Q'             # plat_info (8 bytes)
+        'I'             # key_info (4 bytes)
+        'I'             # _reserved_0 (4 bytes)
+        '64s'           # report_data (64 bytes)
+        '48s'           # measurement (48 bytes)
+        '32s'           # host_data (32 bytes)
+        '48s'           # id_key_digest (48 bytes)
+        '48s'           # author_key_digest (48 bytes)
+        '32s'           # report_id (32 bytes)
+        '32s'           # report_id_ma (32 bytes)
+        'Q'             # reported_tcb (8 bytes)
+        '24s'           # _reserved_1 (24 bytes)
+        '64s'           # chip_id (64 bytes)
+        'Q'             # committed_tcb (8 bytes)
+        'BBBB'          # current_build, current_minor, current_major, _reserved_2
+        'BBBB'          # committed_build, committed_minor, committed_major, _reserved_3
+        'Q'             # launch_tcb (8 bytes)
+        '168s'          # _reserved_4 (168 bytes)
+        '512s'          # signature (512 bytes)
+    )
+
+    @classmethod
+    def calculate_size(cls):
+        """
+        Calculate the total size of the class based on its format string.
+        """
+        return struct.calcsize(cls.FORMAT_STRING)
+
+    def __init__(self):
+        self.version = 0
+        self.guest_svn = 0
+        self.policy = 0
+        self.family_id = [0] * 16
+        self.image_id = [0] * 16
+        self.vmpl = 0
+        self.sig_algo = 0
+        self.current_tcb = SNP_SVN()
+        self.plat_info = PlatformInfo()
+        self.key_info = KeyInfo()
+        self._reserved_0 = 0
+        self.report_data = [0] * 64
+        self.measurement = [0] * 48
+        self.host_data = [0] * 32
+        self.id_key_digest = [0] * 48
+        self.author_key_digest = [0] * 48
+        self.report_id = [0] * 32
+        self.report_id_ma = [0] * 32
+        self.reported_tcb = SNP_SVN()
+        self._reserved_1 = [0] * 24
+        self.chip_id = [0] * 64
+        self.committed_tcb = SNP_SVN()
+        self.current_build = 0
+        self.current_minor = 0
+        self.current_major = 0
+        self._reserved_2 = 0
+        self.committed_build = 0
+        self.committed_minor = 0
+        self.committed_major = 0
+        self._reserved_3 = 0
+        self.launch_tcb = SNP_SVN()
+        self._reserved_4 = [0] * 168
+        self.signature = SNP_SIGNATURE()
+
+    def serialize(self):
+      return struct.pack(
+          self.FORMAT_STRING,
+          self.version,                                  # int
+          self.guest_svn,                                # int
+          self.policy,                                   # int or uint64_t
+          bytes(self.family_id),                         # bytes
+          bytes(self.image_id),                          # bytes
+          self.vmpl,                                     # int
+          self.sig_algo,                                 # int
+          self.current_tcb.serialize(),                 # Should return bytes or int (Q)
+          self.plat_info.serialize(),               # Should return bytes or int (Q)
+          self.key_info.serialize(),                    # Should return bytes or int (I)
+          self._reserved_0,                              # int
+          bytes(self.report_data),                       # bytes
+          bytes(self.measurement),                       # bytes
+          bytes(self.host_data),                         # bytes
+          bytes(self.id_key_digest),                     # bytes
+          bytes(self.author_key_digest),                 # bytes
+          bytes(self.report_id),                         # bytes
+          bytes(self.report_id_ma),                      # bytes
+          self.reported_tcb.serialize(),                # Should return bytes or int (Q)
+          bytes(self._reserved_1),                       # bytes
+          bytes(self.chip_id),                           # bytes
+          self.committed_tcb.serialize(),               # Should return bytes or int (Q)
+          self.current_build,                            # int
+          self.current_minor,                            # int
+          self.current_major,                            # int
+          self._reserved_2,                              # int
+          self.committed_build,                          # int
+          self.committed_minor,                          # int
+          self.committed_major,                          # int
+          self._reserved_3,                              # int
+          self.launch_tcb.serialize(),                  # Should return bytes or int (Q)
+          bytes(self._reserved_4),                       # bytes
+          self.signature.serialize()                    # Should return bytes (512 bytes)
+      )
+
+
+    @classmethod
+    def deserialize(cls, data):
+        """
+        Deserialize a binary blob into an instance of the class.
+        """
+        unpacked_data = struct.unpack(cls.FORMAT_STRING, data)
+
+        instance = cls()
+        instance.version = unpacked_data[0]
+        instance.guest_svn = unpacked_data[1]
+        instance.policy = unpacked_data[2]
+        instance.family_id = list(unpacked_data[3])
+        instance.image_id = list(unpacked_data[4])
+        instance.vmpl = unpacked_data[5]
+        instance.sig_algo = unpacked_data[6]
+        instance.current_tcb = SNP_SVN.deserialize(struct.pack('<Q', unpacked_data[7]))
+        instance.plat_info = PlatformInfo.deserialize(struct.pack('<Q', unpacked_data[8]))
+        instance.key_info = KeyInfo.deserialize(struct.pack('<I', unpacked_data[9]))
+        instance._reserved_0 = unpacked_data[10]
+        instance.report_data = list(unpacked_data[11])
+        instance.measurement = list(unpacked_data[12])
+        instance.host_data = list(unpacked_data[13])
+        instance.id_key_digest = list(unpacked_data[14])
+        instance.author_key_digest = list(unpacked_data[15])
+        instance.report_id = list(unpacked_data[16])
+        instance.report_id_ma = list(unpacked_data[17])
+        instance.reported_tcb = SNP_SVN.deserialize(struct.pack('<Q', unpacked_data[18]))
+        instance._reserved_1 = list(unpacked_data[19])
+        instance.chip_id = list(unpacked_data[20])
+        instance.committed_tcb = SNP_SVN.deserialize(struct.pack('<Q', unpacked_data[21]))
+        instance.current_build = unpacked_data[22]
+        instance.current_minor = unpacked_data[23]
+        instance.current_major = unpacked_data[24]
+        instance._reserved_2 = unpacked_data[25]
+        instance.committed_build = unpacked_data[26]
+        instance.committed_minor = unpacked_data[27]
+        instance.committed_major = unpacked_data[28]
+        instance._reserved_3 = unpacked_data[29]
+        instance.launch_tcb = SNP_SVN.deserialize(struct.pack('<Q', unpacked_data[30]))
+        instance._reserved_4 = list(unpacked_data[31])
+        instance.signature = SNP_SIGNATURE.deserialize(unpacked_data[32])
+
+        return instance
+
+
+    def format_data(self, data):
+      """
+      Format the report data into a multi-line hex output, with 16 bytes per line.
+      """
+      lines = []
+      for i in range(0, len(data), 16):  # Process 16 bytes at a time
+          chunk = data[i:i+16]  # Extract a chunk of 16 bytes
+          lines.append(" ".join(f"{byte:02x}" for byte in chunk))  # Format bytes as hex
+      return "\n".join(lines)
+
+
+    def display(self):
+        print(f"Attestation Report ({self.calculate_size()} bytes):")
+        print(f"Version:                      {self.version}")
+        print(f"Guest SVN:                    {self.guest_svn}")
+        print(f"\nGuest Policy (0x{self.policy:x}):")
+        print(f"    ABI Major:     {(self.policy >> 8) & 0xff}")
+        print(f"    ABI Minor:     {(self.policy >> 0) & 0xff}")
+        print(f"    SMT Allowed:   {(self.policy >> 16) & 0x1}")
+        print(f"    Migrate MA:    {(self.policy >> 18) & 0x1}")
+        print(f"    Debug Allowed: {(self.policy >> 19) & 0x1}")
+        print(f"    Single Socket: {(self.policy >> 20) & 0x1}")
+        print()
+
+        print("Family ID:                    ")
+        for byte in self.family_id:
+            print(f"{byte:02x} ", end='')
+        print()
+        print()
+
+        print("Image ID:                     ")
+        for byte in self.image_id:
+            print(f"{byte:02x} ", end='')
+        print()
+        print()
+
+        print(f"VMPL:                         {self.vmpl}")
+        print(f"Signature Algorithm:          {self.sig_algo}")
+        print()
+
+        current_tcb = self.current_tcb.serialize()
+        formatted_tcb = "".join(f"{byte:02X}" for byte in current_tcb)
+        print(f"Current TCB: {formatted_tcb}")
+        print(f"  Microcode:   {self.current_tcb.microcode}")
+        print(f"  SNP:         {self.current_tcb.snp}")
+        print(f"  TEE:         {self.current_tcb.tee}")
+        print(f"  Boot Loader: {self.current_tcb.bootloader}")
+
+        print(f"\nPlatform Info (1):")
+        print(f"  SMT Enabled:               {self.plat_info.smt_enabled}")
+        print(f"  TSME Enabled:              {self.plat_info.tsme_enabled}")
+        print(f"  ECC Enabled:               {self.plat_info.ecc_enabled}")
+        print(f"  RAPL Disabled:             {self.plat_info.rapl_disabled}")
+        print(f"  Ciphertext Hiding Enabled: {self.plat_info.ciphertext_hiding_enabled}")
+
+        print()
+
+        print(f"Author Key Encryption:      {bool(self.key_info.author_key_en)}")
+        print("Report Data:                     ")
+        print(self.format_data(self.report_data))
+        print()
+
+        print("Measurement:                     ")
+        print(self.format_data(self.measurement))
+        print()
+
+        print("Host Data:                     ")
+        print(self.format_data(self.host_data))
+        print()
+
+        print("ID Key Digest:                     ")
+        print(self.format_data(self.id_key_digest))
+        print()
+
+        print("Report ID:                     ")
+        print(self.format_data(self.report_id))
+        print()
+
+        print("Report ID Migration Agent:                     ")
+        print(self.format_data(self.report_id_ma))
+        print()
+
+        reported_tcb = self.reported_tcb.serialize()
+        formatted_tcb = "".join(f"{byte:02X}" for byte in reported_tcb)
+        print(f"Reported TCB:")
+        print(f"TCB Version: {formatted_tcb}")
+        print(f"  Microcode:   {self.reported_tcb.microcode}")
+        print(f"  SNP:         {self.reported_tcb.snp}")
+        print(f"  TEE:         {self.reported_tcb.tee}")
+        print(f"  Boot Loader: {self.reported_tcb.bootloader}")
+        print()
+
+        print("Chip ID:                     ")
+        print(self.format_data(self.chip_id))
+        print()
+
+        committed_tcb = self.committed_tcb.serialize()
+        formatted_tcb = "".join(f"{byte:02X}" for byte in committed_tcb)
+        print(f"Commited TCB: {formatted_tcb}")
+        print(f"  Microcode:   {self.committed_tcb.microcode}")
+        print(f"  SNP:         {self.committed_tcb.snp}")
+        print(f"  TEE:         {self.committed_tcb.tee}")
+        print(f"  Boot Loader: {self.committed_tcb.bootloader}")
+        print()
+
+        print(f"Current Build:                {self.current_build}")
+        print(f"Current Minor:                {self.current_minor}")
+        print(f"Current Major:                {self.current_major}")
+        print(f"Committed Build:              {self.committed_build}")
+        print(f"Committed Minor:              {self.committed_minor}")
+        print(f"Committed Major:              {self.committed_major}")
+        print()
+
+        launch_tcb = self.launch_tcb.serialize()
+        formatted_tcb = "".join(f"{byte:02X}" for byte in launch_tcb)
+        print(f"Launched TCB: {formatted_tcb}")
+        print(f"  Microcode:   {self.launch_tcb.microcode}")
+        print(f"  SNP:         {self.launch_tcb.snp}")
+        print(f"  TEE:         {self.launch_tcb.tee}")
+        print(f"  Boot Loader: {self.launch_tcb.bootloader}")
+        print()
+
+        print("Signature:                     ")
+        print(f"  R Component:")
+        print(self.format_data(self.signature.r_component))
+        print()
+        print(f"  S Component:")
+        print(self.format_data(self.signature.s_component))
+        print()

--- a/cvm-attestation/snp.py
+++ b/cvm-attestation/snp.py
@@ -2,406 +2,409 @@ import struct
 from typing import List
 
 
-class SNP_SIGNATURE:
-    def __init__(self, r_component=None, s_component=None, reserved=None):
-        self.r_component = r_component or [0] * 72  # RComponent[72]
-        self.s_component = s_component or [0] * 72  # SComponent[72]
-        self.reserved = reserved or [0] * 368       # RSVD[368]
+class Signature:
+  def __init__(self, r_component=None, s_component=None, reserved=None):
+    self.r_component = r_component or [0] * 72  # RComponent[72]
+    self.s_component = s_component or [0] * 72  # SComponent[72]
+    self.reserved = reserved or [0] * 368       # RSVD[368]
 
-    def serialize(self):
-        return struct.pack(
-            '<72s72s368s',
-            bytes(self.r_component),
-            bytes(self.s_component),
-            bytes(self.reserved)
-        )
+  def serialize(self):
+    return struct.pack(
+      '<72s72s368s',
+      bytes(self.r_component),
+      bytes(self.s_component),
+      bytes(self.reserved)
+    )
 
-    @classmethod
-    def deserialize(cls, data):
-        unpacked_data = struct.unpack('<72s72s368s', data)
-        return cls(
-            list(unpacked_data[0]),
-            list(unpacked_data[1]),
-            list(unpacked_data[2])
-        )
+  @classmethod
+  def deserialize(cls, data):
+    unpacked_data = struct.unpack('<72s72s368s', data)
+    return cls(
+      list(unpacked_data[0]),
+      list(unpacked_data[1]),
+      list(unpacked_data[2])
+    )
 
 
-class SNP_SVN:
-    def __init__(self, bootloader=0, tee=0, reserved=0, snp=0, microcode=0):
-        self.bootloader = bootloader
-        self.tee = tee
-        self.reserved = reserved
-        self.snp = snp
-        self.microcode = microcode
+class TcbVersion:
+  def __init__(self, bootloader=0, tee=0, reserved=0, snp=0, microcode=0):
+    self.bootloader = bootloader
+    self.tee = tee
+    self.reserved = reserved
+    self.snp = snp
+    self.microcode = microcode
 
-    def serialize(self):
-        return struct.pack(
-            '>Q',
-            (self.microcode << 56)
-            | (self.snp << 48)
-            | (self.reserved << 16)
-            | (self.tee << 8)
-            | self.bootloader
-        )
+  def serialize(self):
+    return struct.pack(
+      '>Q',
+      (self.microcode << 56)
+      | (self.snp << 48)
+      | (self.reserved << 16)
+      | (self.tee << 8)
+      | self.bootloader
+    )
 
-    @classmethod
-    def deserialize(cls, data):
-        unpacked_data = struct.unpack('<Q', data)[0]
-        return cls(
-            bootloader=unpacked_data & 0xFF,
-            tee=(unpacked_data >> 8) & 0xFF,
-            reserved=(unpacked_data >> 16) & 0xFFFFFFFF,
-            snp=(unpacked_data >> 48) & 0xFF,
-            microcode=(unpacked_data >> 56) & 0xFF
-        )
+  @classmethod
+  def deserialize(cls, data):
+    unpacked_data = struct.unpack('<Q', data)[0]
+    return cls(
+      bootloader=unpacked_data & 0xFF,
+      tee=(unpacked_data >> 8) & 0xFF,
+      reserved=(unpacked_data >> 16) & 0xFFFFFFFF,
+      snp=(unpacked_data >> 48) & 0xFF,
+      microcode=(unpacked_data >> 56) & 0xFF
+    )
 
 class PlatformInfo:
-    def __init__(self, smt_enabled=0, tsme_enabled=0, ecc_enabled=0, rapl_disabled=0, ciphertext_hiding_enabled=0, reserved=0):
-        self.smt_enabled = smt_enabled
-        self.tsme_enabled = tsme_enabled
-        self.ecc_enabled = ecc_enabled
-        self.rapl_disabled = rapl_disabled
-        self.ciphertext_hiding_enabled = ciphertext_hiding_enabled
-        self.reserved = reserved
+  def __init__(self, smt_enabled=0, tsme_enabled=0, ecc_enabled=0, rapl_disabled=0, ciphertext_hiding_enabled=0, reserved=0):
+    self.smt_enabled = smt_enabled
+    self.tsme_enabled = tsme_enabled
+    self.ecc_enabled = ecc_enabled
+    self.rapl_disabled = rapl_disabled
+    self.ciphertext_hiding_enabled = ciphertext_hiding_enabled
+    self.reserved = reserved
 
-    def serialize(self):
-        return (
-            (self.reserved << 5)
-            | (self.ciphertext_hiding_enabled << 4)
-            | (self.rapl_disabled << 3)
-            | (self.ecc_enabled << 2)
-            | (self.tsme_enabled << 1)
-            | self.smt_enabled
-        )
+  def serialize(self):
+    return (
+      (self.reserved << 5)
+      | (self.ciphertext_hiding_enabled << 4)
+      | (self.rapl_disabled << 3)
+      | (self.ecc_enabled << 2)
+      | (self.tsme_enabled << 1)
+      | self.smt_enabled
+    )
 
-    @classmethod
-    def deserialize(cls, data):
-        unpacked_data = struct.unpack('<Q', data)[0]  # Assuming it's a uint64_t
-        return cls(
-            smt_enabled=unpacked_data & 0x1,
-            tsme_enabled=(unpacked_data >> 1) & 0x1,
-            ecc_enabled=(unpacked_data >> 2) & 0x1,
-            rapl_disabled=(unpacked_data >> 3) & 0x1,
-            ciphertext_hiding_enabled=(unpacked_data >> 4) & 0x1,
-            reserved=(unpacked_data >> 5) & ((1 << 59) - 1)  # Mask bits 5 to 63
-        )
+  @classmethod
+  def deserialize(cls, data):
+    unpacked_data = struct.unpack('<Q', data)[0]
+    return cls(
+      smt_enabled=unpacked_data & 0x1,
+      tsme_enabled=(unpacked_data >> 1) & 0x1,
+      ecc_enabled=(unpacked_data >> 2) & 0x1,
+      rapl_disabled=(unpacked_data >> 3) & 0x1,
+      ciphertext_hiding_enabled=(unpacked_data >> 4) & 0x1,
+      reserved=(unpacked_data >> 5) & ((1 << 59) - 1)  # Mask bits 5 to 63
+    )
 
 
 class KeyInfo:
-    def __init__(self, author_key_en=0, mask_chip_key=0, signing_key=0, reserved=0):
-        """
-        Initialize the KeyInfo structure.
-        """
-        self.author_key_en = author_key_en      # Bit 0
-        self.mask_chip_key = mask_chip_key      # Bit 1
-        self.signing_key = signing_key          # Bits 2–4
-        self.reserved = reserved                # Bits 5–31
+  def __init__(self, author_key_en=0, mask_chip_key=0, signing_key=0, reserved=0):
+    """
+    Initialize the KeyInfo structure.
+    """
+    self.author_key_en = author_key_en      # Bit 0
+    self.mask_chip_key = mask_chip_key      # Bit 1
+    self.signing_key = signing_key          # Bits 2–4
+    self.reserved = reserved                # Bits 5–31
 
-    def serialize(self):
-        """
-        Serialize the KeyInfo structure into a 4-byte little-endian integer.
-        """
-        return struct.pack(
-            '<I',
-            (self.reserved << 5) |
-            (self.signing_key << 2) |
-            (self.mask_chip_key << 1) |
-            self.author_key_en
-        )
-
-    @classmethod
-    def deserialize(cls, data):
-        """
-        Deserialize a 4-byte little-endian integer into a KeyInfo instance.
-        """
-        value = struct.unpack('<I', data)[0]
-        return cls(
-            author_key_en=value & 0x1,
-            mask_chip_key=(value >> 1) & 0x1,
-            signing_key=(value >> 2) & 0x7,
-            reserved=(value >> 5) & 0x7FFFFFF
-        )
-
-
-
-class SNP_VM_REPORT:
-    # Define the structure's format string as a class-level constant
-    FORMAT_STRING = (
-        '<IIQ16s16sII'  # version, guest_svn, policy, family_id, image_id, vmpl, sig_algo
-        'Q'             # current_tcb (8 bytes)
-        'Q'             # plat_info (8 bytes)
-        'I'             # key_info (4 bytes)
-        'I'             # _reserved_0 (4 bytes)
-        '64s'           # report_data (64 bytes)
-        '48s'           # measurement (48 bytes)
-        '32s'           # host_data (32 bytes)
-        '48s'           # id_key_digest (48 bytes)
-        '48s'           # author_key_digest (48 bytes)
-        '32s'           # report_id (32 bytes)
-        '32s'           # report_id_ma (32 bytes)
-        'Q'             # reported_tcb (8 bytes)
-        '24s'           # _reserved_1 (24 bytes)
-        '64s'           # chip_id (64 bytes)
-        'Q'             # committed_tcb (8 bytes)
-        'BBBB'          # current_build, current_minor, current_major, _reserved_2
-        'BBBB'          # committed_build, committed_minor, committed_major, _reserved_3
-        'Q'             # launch_tcb (8 bytes)
-        '168s'          # _reserved_4 (168 bytes)
-        '512s'          # signature (512 bytes)
+  def serialize(self):
+    """
+    Serialize the KeyInfo structure into a 4-byte little-endian integer.
+    """
+    return struct.pack(
+      '<I',
+      (self.reserved << 5) |
+      (self.signing_key << 2) |
+      (self.mask_chip_key << 1) |
+      self.author_key_en
     )
 
-    @classmethod
-    def calculate_size(cls):
-        """
-        Calculate the total size of the class based on its format string.
-        """
-        return struct.calcsize(cls.FORMAT_STRING)
-
-    def __init__(self):
-        self.version = 0
-        self.guest_svn = 0
-        self.policy = 0
-        self.family_id = [0] * 16
-        self.image_id = [0] * 16
-        self.vmpl = 0
-        self.sig_algo = 0
-        self.current_tcb = SNP_SVN()
-        self.plat_info = PlatformInfo()
-        self.key_info = KeyInfo()
-        self._reserved_0 = 0
-        self.report_data = [0] * 64
-        self.measurement = [0] * 48
-        self.host_data = [0] * 32
-        self.id_key_digest = [0] * 48
-        self.author_key_digest = [0] * 48
-        self.report_id = [0] * 32
-        self.report_id_ma = [0] * 32
-        self.reported_tcb = SNP_SVN()
-        self._reserved_1 = [0] * 24
-        self.chip_id = [0] * 64
-        self.committed_tcb = SNP_SVN()
-        self.current_build = 0
-        self.current_minor = 0
-        self.current_major = 0
-        self._reserved_2 = 0
-        self.committed_build = 0
-        self.committed_minor = 0
-        self.committed_major = 0
-        self._reserved_3 = 0
-        self.launch_tcb = SNP_SVN()
-        self._reserved_4 = [0] * 168
-        self.signature = SNP_SIGNATURE()
-
-    def serialize(self):
-      return struct.pack(
-          self.FORMAT_STRING,
-          self.version,                                  # int
-          self.guest_svn,                                # int
-          self.policy,                                   # int or uint64_t
-          bytes(self.family_id),                         # bytes
-          bytes(self.image_id),                          # bytes
-          self.vmpl,                                     # int
-          self.sig_algo,                                 # int
-          self.current_tcb.serialize(),                 # Should return bytes or int (Q)
-          self.plat_info.serialize(),               # Should return bytes or int (Q)
-          self.key_info.serialize(),                    # Should return bytes or int (I)
-          self._reserved_0,                              # int
-          bytes(self.report_data),                       # bytes
-          bytes(self.measurement),                       # bytes
-          bytes(self.host_data),                         # bytes
-          bytes(self.id_key_digest),                     # bytes
-          bytes(self.author_key_digest),                 # bytes
-          bytes(self.report_id),                         # bytes
-          bytes(self.report_id_ma),                      # bytes
-          self.reported_tcb.serialize(),                # Should return bytes or int (Q)
-          bytes(self._reserved_1),                       # bytes
-          bytes(self.chip_id),                           # bytes
-          self.committed_tcb.serialize(),               # Should return bytes or int (Q)
-          self.current_build,                            # int
-          self.current_minor,                            # int
-          self.current_major,                            # int
-          self._reserved_2,                              # int
-          self.committed_build,                          # int
-          self.committed_minor,                          # int
-          self.committed_major,                          # int
-          self._reserved_3,                              # int
-          self.launch_tcb.serialize(),                  # Should return bytes or int (Q)
-          bytes(self._reserved_4),                       # bytes
-          self.signature.serialize()                    # Should return bytes (512 bytes)
-      )
+  @classmethod
+  def deserialize(cls, data):
+    """
+    Deserialize a 4-byte little-endian integer into a KeyInfo instance.
+    """
+    value = struct.unpack('<I', data)[0]
+    return cls(
+      author_key_en=value & 0x1,
+      mask_chip_key=(value >> 1) & 0x1,
+      signing_key=(value >> 2) & 0x7,
+      reserved=(value >> 5) & 0x7FFFFFF
+    )
 
 
-    @classmethod
-    def deserialize(cls, data):
-        """
-        Deserialize a binary blob into an instance of the class.
-        """
-        unpacked_data = struct.unpack(cls.FORMAT_STRING, data)
 
-        instance = cls()
-        instance.version = unpacked_data[0]
-        instance.guest_svn = unpacked_data[1]
-        instance.policy = unpacked_data[2]
-        instance.family_id = list(unpacked_data[3])
-        instance.image_id = list(unpacked_data[4])
-        instance.vmpl = unpacked_data[5]
-        instance.sig_algo = unpacked_data[6]
-        instance.current_tcb = SNP_SVN.deserialize(struct.pack('<Q', unpacked_data[7]))
-        instance.plat_info = PlatformInfo.deserialize(struct.pack('<Q', unpacked_data[8]))
-        instance.key_info = KeyInfo.deserialize(struct.pack('<I', unpacked_data[9]))
-        instance._reserved_0 = unpacked_data[10]
-        instance.report_data = list(unpacked_data[11])
-        instance.measurement = list(unpacked_data[12])
-        instance.host_data = list(unpacked_data[13])
-        instance.id_key_digest = list(unpacked_data[14])
-        instance.author_key_digest = list(unpacked_data[15])
-        instance.report_id = list(unpacked_data[16])
-        instance.report_id_ma = list(unpacked_data[17])
-        instance.reported_tcb = SNP_SVN.deserialize(struct.pack('<Q', unpacked_data[18]))
-        instance._reserved_1 = list(unpacked_data[19])
-        instance.chip_id = list(unpacked_data[20])
-        instance.committed_tcb = SNP_SVN.deserialize(struct.pack('<Q', unpacked_data[21]))
-        instance.current_build = unpacked_data[22]
-        instance.current_minor = unpacked_data[23]
-        instance.current_major = unpacked_data[24]
-        instance._reserved_2 = unpacked_data[25]
-        instance.committed_build = unpacked_data[26]
-        instance.committed_minor = unpacked_data[27]
-        instance.committed_major = unpacked_data[28]
-        instance._reserved_3 = unpacked_data[29]
-        instance.launch_tcb = SNP_SVN.deserialize(struct.pack('<Q', unpacked_data[30]))
-        instance._reserved_4 = list(unpacked_data[31])
-        instance.signature = SNP_SIGNATURE.deserialize(unpacked_data[32])
+class AttestationReport:
+  # Define the structure's format string as a class-level constant
+  FORMAT_STRING = (
+    '<IIQ16s16sII'  # version, guest_svn, policy, family_id, image_id, vmpl, sig_algo
+    'Q'             # current_tcb (8 bytes)
+    'Q'             # plat_info (8 bytes)
+    'I'             # key_info (4 bytes)
+    'I'             # _reserved_0 (4 bytes)
+    '64s'           # report_data (64 bytes)
+    '48s'           # measurement (48 bytes)
+    '32s'           # host_data (32 bytes)
+    '48s'           # id_key_digest (48 bytes)
+    '48s'           # author_key_digest (48 bytes)
+    '32s'           # report_id (32 bytes)
+    '32s'           # report_id_ma (32 bytes)
+    'Q'             # reported_tcb (8 bytes)
+    '24s'           # _reserved_1 (24 bytes)
+    '64s'           # chip_id (64 bytes)
+    'Q'             # committed_tcb (8 bytes)
+    'BBBB'          # current_build, current_minor, current_major, _reserved_2
+    'BBBB'          # committed_build, committed_minor, committed_major, _reserved_3
+    'Q'             # launch_tcb (8 bytes)
+    '168s'          # _reserved_4 (168 bytes)
+    '512s'          # signature (512 bytes)
+  )
 
-        return instance
+  @classmethod
+  def calculate_size(cls):
+    """
+    Calculate the total size of the class based on its format string.
+    """
+    return struct.calcsize(cls.FORMAT_STRING)
+
+  def __init__(self):
+    self.version = 0
+    self.guest_svn = 0
+    self.policy = 0
+    self.family_id = [0] * 16
+    self.image_id = [0] * 16
+    self.vmpl = 0
+    self.sig_algo = 0
+    self.current_tcb = TcbVersion()
+    self.plat_info = PlatformInfo()
+    self.key_info = KeyInfo()
+    self._reserved_0 = 0
+    self.report_data = [0] * 64
+    self.measurement = [0] * 48
+    self.host_data = [0] * 32
+    self.id_key_digest = [0] * 48
+    self.author_key_digest = [0] * 48
+    self.report_id = [0] * 32
+    self.report_id_ma = [0] * 32
+    self.reported_tcb = TcbVersion()
+    self._reserved_1 = [0] * 24
+    self.chip_id = [0] * 64
+    self.committed_tcb = TcbVersion()
+    self.current_build = 0
+    self.current_minor = 0
+    self.current_major = 0
+    self._reserved_2 = 0
+    self.committed_build = 0
+    self.committed_minor = 0
+    self.committed_major = 0
+    self._reserved_3 = 0
+    self.launch_tcb = TcbVersion()
+    self._reserved_4 = [0] * 168
+    self.signature = Signature()
+
+  def serialize(self):
+    return struct.pack(
+      self.FORMAT_STRING,
+      self.version,                     # int
+      self.guest_svn,                   # int
+      self.policy,                      # int or uint64_t
+      bytes(self.family_id),            # bytes
+      bytes(self.image_id),             # bytes
+      self.vmpl,                        # int
+      self.sig_algo,                    # int
+      self.current_tcb.serialize(),     # Should return bytes or int (Q)
+      self.plat_info.serialize(),       # Should return bytes or int (Q)
+      self.key_info.serialize(),        # Should return bytes or int (I)
+      self._reserved_0,                 # int
+      bytes(self.report_data),          # bytes
+      bytes(self.measurement),          # bytes
+      bytes(self.host_data),            # bytes
+      bytes(self.id_key_digest),        # bytes
+      bytes(self.author_key_digest),    # bytes
+      bytes(self.report_id),            # bytes
+      bytes(self.report_id_ma),         # bytes
+      self.reported_tcb.serialize(),    # Should return bytes or int (Q)
+      bytes(self._reserved_1),          # bytes
+      bytes(self.chip_id),              # bytes
+      self.committed_tcb.serialize(),   # Should return bytes or int (Q)
+      self.current_build,               # int
+      self.current_minor,               # int
+      self.current_major,               # int
+      self._reserved_2,                 # int
+      self.committed_build,             # int
+      self.committed_minor,             # int
+      self.committed_major,             # int
+      self._reserved_3,                 # int
+      self.launch_tcb.serialize(),      # Should return bytes or int (Q)
+      bytes(self._reserved_4),          # bytes
+      self.signature.serialize()        # Should return bytes (512 bytes)
+    )
 
 
-    def format_data(self, data):
-      """
-      Format the report data into a multi-line hex output, with 16 bytes per line.
-      """
-      lines = []
-      for i in range(0, len(data), 16):  # Process 16 bytes at a time
-          chunk = data[i:i+16]  # Extract a chunk of 16 bytes
-          lines.append(" ".join(f"{byte:02x}" for byte in chunk))  # Format bytes as hex
-      return "\n".join(lines)
+  @classmethod
+  def deserialize(cls, data):
+    """
+    Deserialize a binary blob into an instance of the class.
+    """
+    unpacked_data = struct.unpack(cls.FORMAT_STRING, data)
+
+    instance = cls()
+    instance.version = unpacked_data[0]
+    instance.guest_svn = unpacked_data[1]
+    instance.policy = unpacked_data[2]
+    instance.family_id = list(unpacked_data[3])
+    instance.image_id = list(unpacked_data[4])
+    instance.vmpl = unpacked_data[5]
+    instance.sig_algo = unpacked_data[6]
+    instance.current_tcb = TcbVersion.deserialize(struct.pack('<Q', unpacked_data[7]))
+    instance.plat_info = PlatformInfo.deserialize(struct.pack('<Q', unpacked_data[8]))
+    instance.key_info = KeyInfo.deserialize(struct.pack('<I', unpacked_data[9]))
+    instance._reserved_0 = unpacked_data[10]
+    instance.report_data = list(unpacked_data[11])
+    instance.measurement = list(unpacked_data[12])
+    instance.host_data = list(unpacked_data[13])
+    instance.id_key_digest = list(unpacked_data[14])
+    instance.author_key_digest = list(unpacked_data[15])
+    instance.report_id = list(unpacked_data[16])
+    instance.report_id_ma = list(unpacked_data[17])
+    instance.reported_tcb = TcbVersion.deserialize(struct.pack('<Q', unpacked_data[18]))
+    instance._reserved_1 = list(unpacked_data[19])
+    instance.chip_id = list(unpacked_data[20])
+    instance.committed_tcb = TcbVersion.deserialize(struct.pack('<Q', unpacked_data[21]))
+    instance.current_build = unpacked_data[22]
+    instance.current_minor = unpacked_data[23]
+    instance.current_major = unpacked_data[24]
+    instance._reserved_2 = unpacked_data[25]
+    instance.committed_build = unpacked_data[26]
+    instance.committed_minor = unpacked_data[27]
+    instance.committed_major = unpacked_data[28]
+    instance._reserved_3 = unpacked_data[29]
+    instance.launch_tcb = TcbVersion.deserialize(struct.pack('<Q', unpacked_data[30]))
+    instance._reserved_4 = list(unpacked_data[31])
+    instance.signature = Signature.deserialize(unpacked_data[32])
+
+    return instance
 
 
-    def display(self):
-        print(f"Attestation Report ({self.calculate_size()} bytes):")
-        print(f"Version:                      {self.version}")
-        print(f"Guest SVN:                    {self.guest_svn}")
-        print(f"\nGuest Policy (0x{self.policy:x}):")
-        print(f"    ABI Major:     {(self.policy >> 8) & 0xff}")
-        print(f"    ABI Minor:     {(self.policy >> 0) & 0xff}")
-        print(f"    SMT Allowed:   {(self.policy >> 16) & 0x1}")
-        print(f"    Migrate MA:    {(self.policy >> 18) & 0x1}")
-        print(f"    Debug Allowed: {(self.policy >> 19) & 0x1}")
-        print(f"    Single Socket: {(self.policy >> 20) & 0x1}")
-        print()
+  def format_data(self, data):
+    """
+    Format the report data into a multi-line hex output, with 16 bytes per line.
+    """
+    lines = []
+    for i in range(0, len(data), 16):
+      chunk = data[i:i+16]
+      lines.append(" ".join(f"{byte:02x}" for byte in chunk))  # Format bytes as hex
+    return "\n".join(lines)
 
-        print("Family ID:                    ")
-        for byte in self.family_id:
-            print(f"{byte:02x} ", end='')
-        print()
-        print()
 
-        print("Image ID:                     ")
-        for byte in self.image_id:
-            print(f"{byte:02x} ", end='')
-        print()
-        print()
+  def display(self):
+    """
+    Displays the full attestation report
+    """
+    print(f"Attestation Report ({self.calculate_size()} bytes):")
+    print(f"Version:                      {self.version}")
+    print(f"Guest SVN:                    {self.guest_svn}")
+    print(f"\nGuest Policy (0x{self.policy:x}):")
+    print(f"    ABI Major:     {(self.policy >> 8) & 0xff}")
+    print(f"    ABI Minor:     {(self.policy >> 0) & 0xff}")
+    print(f"    SMT Allowed:   {(self.policy >> 16) & 0x1}")
+    print(f"    Migrate MA:    {(self.policy >> 18) & 0x1}")
+    print(f"    Debug Allowed: {(self.policy >> 19) & 0x1}")
+    print(f"    Single Socket: {(self.policy >> 20) & 0x1}")
+    print()
 
-        print(f"VMPL:                         {self.vmpl}")
-        print(f"Signature Algorithm:          {self.sig_algo}")
-        print()
+    print("Family ID:                    ")
+    for byte in self.family_id:
+      print(f"{byte:02x} ", end='')
+    print()
+    print()
 
-        current_tcb = self.current_tcb.serialize()
-        formatted_tcb = "".join(f"{byte:02X}" for byte in current_tcb)
-        print(f"Current TCB: {formatted_tcb}")
-        print(f"  Microcode:   {self.current_tcb.microcode}")
-        print(f"  SNP:         {self.current_tcb.snp}")
-        print(f"  TEE:         {self.current_tcb.tee}")
-        print(f"  Boot Loader: {self.current_tcb.bootloader}")
+    print("Image ID:                     ")
+    for byte in self.image_id:
+      print(f"{byte:02x} ", end='')
+    print()
+    print()
 
-        print(f"\nPlatform Info (1):")
-        print(f"  SMT Enabled:               {self.plat_info.smt_enabled}")
-        print(f"  TSME Enabled:              {self.plat_info.tsme_enabled}")
-        print(f"  ECC Enabled:               {self.plat_info.ecc_enabled}")
-        print(f"  RAPL Disabled:             {self.plat_info.rapl_disabled}")
-        print(f"  Ciphertext Hiding Enabled: {self.plat_info.ciphertext_hiding_enabled}")
+    print(f"VMPL:                         {self.vmpl}")
+    print(f"Signature Algorithm:          {self.sig_algo}")
+    print()
 
-        print()
+    current_tcb = self.current_tcb.serialize()
+    formatted_tcb = "".join(f"{byte:02X}" for byte in current_tcb)
+    print(f"Current TCB: {formatted_tcb}")
+    print(f"  Microcode:   {self.current_tcb.microcode}")
+    print(f"  SNP:         {self.current_tcb.snp}")
+    print(f"  TEE:         {self.current_tcb.tee}")
+    print(f"  Boot Loader: {self.current_tcb.bootloader}")
 
-        print(f"Author Key Encryption:      {bool(self.key_info.author_key_en)}")
-        print("Report Data:                     ")
-        print(self.format_data(self.report_data))
-        print()
+    print(f"\nPlatform Info (1):")
+    print(f"  SMT Enabled:               {self.plat_info.smt_enabled}")
+    print(f"  TSME Enabled:              {self.plat_info.tsme_enabled}")
+    print(f"  ECC Enabled:               {self.plat_info.ecc_enabled}")
+    print(f"  RAPL Disabled:             {self.plat_info.rapl_disabled}")
+    print(f"  Ciphertext Hiding Enabled: {self.plat_info.ciphertext_hiding_enabled}")
 
-        print("Measurement:                     ")
-        print(self.format_data(self.measurement))
-        print()
+    print()
 
-        print("Host Data:                     ")
-        print(self.format_data(self.host_data))
-        print()
+    print(f"Author Key Encryption:      {bool(self.key_info.author_key_en)}")
+    print("Report Data:                     ")
+    print(self.format_data(self.report_data))
+    print()
 
-        print("ID Key Digest:                     ")
-        print(self.format_data(self.id_key_digest))
-        print()
+    print("Measurement:                     ")
+    print(self.format_data(self.measurement))
+    print()
 
-        print("Report ID:                     ")
-        print(self.format_data(self.report_id))
-        print()
+    print("Host Data:                     ")
+    print(self.format_data(self.host_data))
+    print()
 
-        print("Report ID Migration Agent:                     ")
-        print(self.format_data(self.report_id_ma))
-        print()
+    print("ID Key Digest:                     ")
+    print(self.format_data(self.id_key_digest))
+    print()
 
-        reported_tcb = self.reported_tcb.serialize()
-        formatted_tcb = "".join(f"{byte:02X}" for byte in reported_tcb)
-        print(f"Reported TCB:")
-        print(f"TCB Version: {formatted_tcb}")
-        print(f"  Microcode:   {self.reported_tcb.microcode}")
-        print(f"  SNP:         {self.reported_tcb.snp}")
-        print(f"  TEE:         {self.reported_tcb.tee}")
-        print(f"  Boot Loader: {self.reported_tcb.bootloader}")
-        print()
+    print("Report ID:                     ")
+    print(self.format_data(self.report_id))
+    print()
 
-        print("Chip ID:                     ")
-        print(self.format_data(self.chip_id))
-        print()
+    print("Report ID Migration Agent:                     ")
+    print(self.format_data(self.report_id_ma))
+    print()
 
-        committed_tcb = self.committed_tcb.serialize()
-        formatted_tcb = "".join(f"{byte:02X}" for byte in committed_tcb)
-        print(f"Commited TCB: {formatted_tcb}")
-        print(f"  Microcode:   {self.committed_tcb.microcode}")
-        print(f"  SNP:         {self.committed_tcb.snp}")
-        print(f"  TEE:         {self.committed_tcb.tee}")
-        print(f"  Boot Loader: {self.committed_tcb.bootloader}")
-        print()
+    reported_tcb = self.reported_tcb.serialize()
+    formatted_tcb = "".join(f"{byte:02X}" for byte in reported_tcb)
+    print(f"Reported TCB:")
+    print(f"TCB Version: {formatted_tcb}")
+    print(f"  Microcode:   {self.reported_tcb.microcode}")
+    print(f"  SNP:         {self.reported_tcb.snp}")
+    print(f"  TEE:         {self.reported_tcb.tee}")
+    print(f"  Boot Loader: {self.reported_tcb.bootloader}")
+    print()
 
-        print(f"Current Build:                {self.current_build}")
-        print(f"Current Minor:                {self.current_minor}")
-        print(f"Current Major:                {self.current_major}")
-        print(f"Committed Build:              {self.committed_build}")
-        print(f"Committed Minor:              {self.committed_minor}")
-        print(f"Committed Major:              {self.committed_major}")
-        print()
+    print("Chip ID:                     ")
+    print(self.format_data(self.chip_id))
+    print()
 
-        launch_tcb = self.launch_tcb.serialize()
-        formatted_tcb = "".join(f"{byte:02X}" for byte in launch_tcb)
-        print(f"Launched TCB: {formatted_tcb}")
-        print(f"  Microcode:   {self.launch_tcb.microcode}")
-        print(f"  SNP:         {self.launch_tcb.snp}")
-        print(f"  TEE:         {self.launch_tcb.tee}")
-        print(f"  Boot Loader: {self.launch_tcb.bootloader}")
-        print()
+    committed_tcb = self.committed_tcb.serialize()
+    formatted_tcb = "".join(f"{byte:02X}" for byte in committed_tcb)
+    print(f"Commited TCB: {formatted_tcb}")
+    print(f"  Microcode:   {self.committed_tcb.microcode}")
+    print(f"  SNP:         {self.committed_tcb.snp}")
+    print(f"  TEE:         {self.committed_tcb.tee}")
+    print(f"  Boot Loader: {self.committed_tcb.bootloader}")
+    print()
 
-        print("Signature:                     ")
-        print(f"  R Component:")
-        print(self.format_data(self.signature.r_component))
-        print()
-        print(f"  S Component:")
-        print(self.format_data(self.signature.s_component))
-        print()
+    print(f"Current Build:                {self.current_build}")
+    print(f"Current Minor:                {self.current_minor}")
+    print(f"Current Major:                {self.current_major}")
+    print(f"Committed Build:              {self.committed_build}")
+    print(f"Committed Minor:              {self.committed_minor}")
+    print(f"Committed Major:              {self.committed_major}")
+    print()
+
+    launch_tcb = self.launch_tcb.serialize()
+    formatted_tcb = "".join(f"{byte:02X}" for byte in launch_tcb)
+    print(f"Launched TCB: {formatted_tcb}")
+    print(f"  Microcode:   {self.launch_tcb.microcode}")
+    print(f"  SNP:         {self.launch_tcb.snp}")
+    print(f"  TEE:         {self.launch_tcb.tee}")
+    print(f"  Boot Loader: {self.launch_tcb.bootloader}")
+    print()
+
+    print("Signature:                     ")
+    print(f"  R Component:")
+    print(self.format_data(self.signature.r_component))
+    print()
+    print(f"  S Component:")
+    print(self.format_data(self.signature.s_component))
+    print()

--- a/cvm-attestation/snp.py
+++ b/cvm-attestation/snp.py
@@ -36,17 +36,17 @@ class TcbVersion:
 
   def serialize(self):
     return struct.pack(
-      '<Q',
-      (self.microcode << 56)
-      | (self.snp << 48)
-      | (self.reserved << 16)
+      '<Q',  # Little-endian unsigned 64-bit integer
+      (self.bootloader)
       | (self.tee << 8)
-      | self.bootloader
+      | (self.reserved << 16)
+      | (self.snp << 48)
+      | (self.microcode << 56)
     )
 
   @classmethod
   def deserialize(cls, data):
-    unpacked_data = struct.unpack('<Q', data)[0]
+    unpacked_data = struct.unpack('<Q', data)[0] # Little-endian unsigned 64-bit integer
     return cls(
       bootloader=unpacked_data & 0xFF,
       tee=(unpacked_data >> 8) & 0xFF,
@@ -73,11 +73,11 @@ class PlatformInfo:
       | (self.tsme_enabled << 1)
       | self.smt_enabled
     )
-    return struct.pack('<Q', value)  # '<Q' packs an unsigned 8-byte integer
+    return struct.pack('<Q', value)  # Little-endian unsigned 64-bit integer
 
   @classmethod
   def deserialize(cls, data):
-    unpacked_data = struct.unpack('<Q', data)[0]
+    unpacked_data = struct.unpack('<Q', data)[0] # Little-endian unsigned 64-bit integer
     return cls(
       smt_enabled=unpacked_data & 0x1,
       tsme_enabled=(unpacked_data >> 1) & 0x1,
@@ -329,7 +329,7 @@ class AttestationReport:
     print()
 
     current_tcb = self.current_tcb.serialize()
-    formatted_tcb = "".join(f"{byte:02X}" for byte in current_tcb)
+    formatted_tcb = "".join(f"{byte:02X}" for byte in current_tcb[::-1])
     print(f"Current TCB: {formatted_tcb}")
     print(f"  Microcode:   {self.current_tcb.microcode}")
     print(f"  SNP:         {self.current_tcb.snp}")
@@ -371,7 +371,7 @@ class AttestationReport:
     print()
 
     reported_tcb = self.reported_tcb.serialize()
-    formatted_tcb = "".join(f"{byte:02X}" for byte in reported_tcb)
+    formatted_tcb = "".join(f"{byte:02X}" for byte in reported_tcb[::-1])
     print(f"Reported TCB:")
     print(f"TCB Version: {formatted_tcb}")
     print(f"  Microcode:   {self.reported_tcb.microcode}")
@@ -385,7 +385,7 @@ class AttestationReport:
     print()
 
     committed_tcb = self.committed_tcb.serialize()
-    formatted_tcb = "".join(f"{byte:02X}" for byte in committed_tcb)
+    formatted_tcb = "".join(f"{byte:02X}" for byte in committed_tcb[::-1])
     print(f"Commited TCB: {formatted_tcb}")
     print(f"  Microcode:   {self.committed_tcb.microcode}")
     print(f"  SNP:         {self.committed_tcb.snp}")
@@ -402,7 +402,7 @@ class AttestationReport:
     print()
 
     launch_tcb = self.launch_tcb.serialize()
-    formatted_tcb = "".join(f"{byte:02X}" for byte in launch_tcb)
+    formatted_tcb = "".join(f"{byte:02X}" for byte in launch_tcb[::-1])
     print(f"Launched TCB: {formatted_tcb}")
     print(f"  Microcode:   {self.launch_tcb.microcode}")
     print(f"  SNP:         {self.launch_tcb.snp}")

--- a/cvm-attestation/snp.py
+++ b/cvm-attestation/snp.py
@@ -125,6 +125,10 @@ class KeyInfo:
 
 
 class AttestationReport:
+    """
+    Defines an AttestationReport class from the SEV-SNP attestation report.
+    Source: https://github.com/virtee/sev/blob/f9c6abe7b021cdf9e5c03c56169d4d479fc64464/src/firmware/guest/types/snp.rs#L127C1-L127C31.
+    """
   # Define the structure's format string as a class-level constant
   FORMAT_STRING = (
     '<IIQ16s16sII'  # version, guest_svn, policy, family_id, image_id, vmpl, sig_algo
@@ -193,6 +197,9 @@ class AttestationReport:
     self.signature = Signature()
 
   def serialize(self):
+    """
+    Serializes an AttestationReport instance into a binary blob.
+    """
     return struct.pack(
       self.FORMAT_STRING,
       self.version,                     # int
@@ -234,7 +241,7 @@ class AttestationReport:
   @classmethod
   def deserialize(cls, data):
     """
-    Deserialize a binary blob into an instance of the class.
+    Deserialize a binary blob into an instance of the AttestationReport class.
     """
     unpacked_data = struct.unpack(cls.FORMAT_STRING, data)
 

--- a/cvm-attestation/test_snp.py
+++ b/cvm-attestation/test_snp.py
@@ -1,0 +1,138 @@
+import pytest
+import struct
+from snp import Signature, TcbVersion, PlatformInfo, KeyInfo, AttestationReport
+
+
+@pytest.fixture
+def sample_signature():
+  return Signature(
+    r_component=[0x01] * 72,
+    s_component=[0x02] * 72,
+    reserved=[0x00] * 368,
+  )
+
+
+@pytest.fixture
+def sample_tcb_version():
+  return TcbVersion(bootloader=1, tee=2, reserved=0, snp=3, microcode=4)
+
+
+@pytest.fixture
+def sample_platform_info():
+  return PlatformInfo(
+    smt_enabled=1,
+    tsme_enabled=0,
+    ecc_enabled=1,
+    rapl_disabled=1,
+    ciphertext_hiding_enabled=0,
+    reserved=42,
+  )
+
+
+@pytest.fixture
+def sample_key_info():
+  return KeyInfo(author_key_en=1, mask_chip_key=0, signing_key=5, reserved=0)
+
+
+@pytest.fixture
+def sample_attestation_report(sample_signature, sample_tcb_version, sample_platform_info, sample_key_info):
+  report = AttestationReport()
+  report.version = 1
+  report.guest_svn = 2
+  report.policy = 0xABCD1234
+  report.family_id = [0x01] * 16
+  report.image_id = [0x02] * 16
+  report.vmpl = 3
+  report.sig_algo = 0x102
+  report.current_tcb = sample_tcb_version
+  report.plat_info = sample_platform_info
+  report.key_info = sample_key_info
+  report.report_data = [0x03] * 64
+  report.measurement = [0x04] * 48
+  report.host_data = [0x05] * 32
+  report.id_key_digest = [0x06] * 48
+  report.author_key_digest = [0x07] * 48
+  report.report_id = [0x08] * 32
+  report.report_id_ma = [0x09] * 32
+  report.reported_tcb = sample_tcb_version
+  report.chip_id = [0x10] * 64
+  report.committed_tcb = sample_tcb_version
+  report.signature = sample_signature
+  return report
+
+
+def test_signature_serialize_deserialize(sample_signature):
+  serialized = sample_signature.serialize()
+  assert len(serialized) == 512
+
+  deserialized = Signature.deserialize(serialized)
+  assert deserialized.r_component == sample_signature.r_component
+  assert deserialized.s_component == sample_signature.s_component
+  assert deserialized.reserved == sample_signature.reserved
+
+
+def test_tcb_version_serialize_deserialize(sample_tcb_version):
+  serialized = sample_tcb_version.serialize()
+  assert len(serialized) == 8
+
+  deserialized = TcbVersion.deserialize(serialized)
+  assert deserialized.bootloader == sample_tcb_version.bootloader
+  assert deserialized.tee == sample_tcb_version.tee
+  assert deserialized.reserved == sample_tcb_version.reserved
+  assert deserialized.snp == sample_tcb_version.snp
+  assert deserialized.microcode == sample_tcb_version.microcode
+
+
+def test_platform_info_serialize_deserialize(sample_platform_info):
+  serialized_value = sample_platform_info.serialize()
+  serialized = struct.pack('<Q', int.from_bytes(serialized_value, byteorder='little'))
+  assert len(serialized) == 8
+
+  deserialized = PlatformInfo.deserialize(serialized)
+  assert deserialized.smt_enabled == sample_platform_info.smt_enabled
+  assert deserialized.tsme_enabled == sample_platform_info.tsme_enabled
+  assert deserialized.ecc_enabled == sample_platform_info.ecc_enabled
+  assert deserialized.rapl_disabled == sample_platform_info.rapl_disabled
+  assert deserialized.ciphertext_hiding_enabled == sample_platform_info.ciphertext_hiding_enabled
+  assert deserialized.reserved == sample_platform_info.reserved
+
+
+def test_key_info_serialize_deserialize(sample_key_info):
+  serialized = sample_key_info.serialize()
+  assert len(serialized) == 4
+
+  deserialized = KeyInfo.deserialize(serialized)
+  assert deserialized.author_key_en == sample_key_info.author_key_en
+  assert deserialized.mask_chip_key == sample_key_info.mask_chip_key
+  assert deserialized.signing_key == sample_key_info.signing_key
+  assert deserialized.reserved == sample_key_info.reserved
+
+
+def test_attestation_report_serialize_deserialize(sample_attestation_report):
+  serialized = sample_attestation_report.serialize()
+  assert len(serialized) == AttestationReport.calculate_size()
+  
+
+  deserialized = AttestationReport.deserialize(serialized)
+  assert deserialized.version == sample_attestation_report.version
+  assert deserialized.guest_svn == sample_attestation_report.guest_svn
+  assert deserialized.policy == sample_attestation_report.policy
+  assert deserialized.family_id == sample_attestation_report.family_id
+  assert deserialized.image_id == sample_attestation_report.image_id
+  assert deserialized.vmpl == sample_attestation_report.vmpl
+  assert deserialized.sig_algo == sample_attestation_report.sig_algo
+  assert deserialized.report_data == sample_attestation_report.report_data
+  assert deserialized.measurement == sample_attestation_report.measurement
+  assert deserialized.host_data == sample_attestation_report.host_data
+  assert deserialized.id_key_digest == sample_attestation_report.id_key_digest
+  assert deserialized.author_key_digest == sample_attestation_report.author_key_digest
+  assert deserialized.report_id == sample_attestation_report.report_id
+  assert deserialized.report_id_ma == sample_attestation_report.report_id_ma
+
+
+def test_attestation_report_display(capsys, sample_attestation_report):
+  sample_attestation_report.display()
+  captured = capsys.readouterr()
+  assert "Attestation Report" in captured.out
+  assert "Version:" in captured.out
+  assert "Guest SVN:" in captured.out

--- a/cvm-attestation/tests/test_ImdsClient.py
+++ b/cvm-attestation/tests/test_ImdsClient.py
@@ -108,7 +108,7 @@ def test_vcek_cert_request_retries_if_error_code_is_returned(mocker, imds_client
                 imds_client.get_vcek_certificate()
             assert mock_post.call_count == 5
         assert 'Error 400: Error message' in str(excinfo.value)
-        mock_sleep.assert_called_with(1)
+        mock_sleep.assert_called_with(8)
         assert mock_sleep.call_count == 4
 
 
@@ -122,7 +122,7 @@ def test_vcek_cert_request_fails_with_http_400(mocker, imds_client):
         with pytest.raises(VcekCertException) as excinfo:
             imds_client.get_vcek_certificate()
         assert 'Error 400: Error message' in str(excinfo.value)
-        mock_sleep.assert_called_with(1)
+        mock_sleep.assert_called_with(8)
         assert mock_sleep.call_count == 4
 
 

--- a/cvm-attestation/tests/test_ReportParser.py
+++ b/cvm-attestation/tests/test_ReportParser.py
@@ -3,11 +3,14 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
 
+import os
 import pytest
 from src.ReportParser import ReportParser
 
 def read_hcl_report():
-    file = open("tests/report.bin","rb")
+    current_dir = os.path.dirname(__file__)
+    file_path = os.path.join(current_dir, "report.bin")
+    file = open(file_path,"rb")
     hcl_report = file.read()
     file.close()
 


### PR DESCRIPTION
Adds new cli command to read hardware report and save it. 
Changes:
- [X] Read and save hardware report
- [X] Include SNP Attestation Report structure
- [X] Parses SNP Attestation report to get different TCB versions
- [X] New CLI command to read the report `read_report`
- [x] Unit Tests
- [X] Tested in Linux CVM
- [x] Tested in Windows CVM

# New CLI command
## read_report (only SNP)
Tool to read the Attestation report from the hardware the CVM is running on.

### Run CLI Tool
Running default to get the Attestation Report
``` bash
sudo read_report
```

#### `--t` or `-type` Attestation Type (optional)
Option to provide type of attestation to be run.
```
sudo read_report  --t snp_report
```


#### `--o` or `-out` Output filename (optional)
The name of the output file to store the report
```
sudo read_report  --o report.bin
```