### PR TITLE
Add backoff retry if there is no Retry-After in response headers

### DIFF
--- a/cvm-attestation/src/AttestationProvider.py
+++ b/cvm-attestation/src/AttestationProvider.py
@@ -62,31 +62,24 @@ class MAAProvider(IAttestationProvider):
     self.endpoint = endpoint
 
 
-  def attest_platform(self, evidence, runtime_data):
+  def _send_attestation_request(self, payload):
     """
-    Verfies the Hardware Evidence provided by the Attester
+    Sends an attestation request to the provider with retries and exponential backoff.
     """
-
-    # Sends request to MAA using exponential backoff to handle
-    # any transient network issue.
     max_retries = 5
-    retries = 0
     backoff_factor = 1
+    retries = 0
+
     while retries < max_retries:
       try:
-        payload = self.create_payload(evidence, runtime_data)
-
         self.log.info("Sending attestation request to provider...")
 
-        # Sends request to MAA for attesting the guest
         response = requests.post(
           self.endpoint,
           data=json.dumps(payload),
           headers=DEFAULT_HEADERS
         )
 
-        # Check the response from the server if there is an error
-        # we retry until all retries have been exhausted
         if response.status_code == 200:
           self.log.info("Received token from attestation provider")
           response_json = json.loads(response.text)
@@ -97,21 +90,19 @@ class MAAProvider(IAttestationProvider):
           self.log.error(
             f"Failed to verify evidence due to invalid collateral, error: {response.text}"
           )
-
           return None
-        elif response.status_code == 429: # Too Many Requests
-          self.log.warning(
-            f"Too many requests, error: {response.text}"
-          )
-
+        elif response.status_code == 429:
+          self.log.warning(f"Too many requests, error: {response.text}")
           retries += 1
           if retries < max_retries:
-            headers = response.headers
-            retry_after = headers.get('Retry-After')
-            sleep_time = int((retry_after))
-
+            retry_after = response.headers.get('Retry-After')
             if retry_after:
-              self.log.info(f"Retrying in {retry_after} seconds...")
+              sleep_time = int(retry_after)
+              self.log.info(f"Retrying in {sleep_time} seconds...")
+              time.sleep(sleep_time)
+            else:
+              sleep_time = backoff_factor * (2 ** (retries - 1))
+              self.log.info(f"Retrying in {sleep_time} seconds...")
               time.sleep(sleep_time)
           else:
             raise AttestationProviderException(
@@ -121,7 +112,6 @@ class MAAProvider(IAttestationProvider):
           self.log.error(
             f"Failed to verify evidence, status code: {response.status_code}, error: {response.text}"
           )
-
           retries += 1
           if retries < max_retries:
             sleep_time = backoff_factor * (2 ** (retries - 1))
@@ -131,9 +121,9 @@ class MAAProvider(IAttestationProvider):
             raise AttestationProviderException(
               f"Unexpected status code: {response.status_code}, error: {response.text}"
             )
+
       except RequestException as e:
         self.log.error(f"Request failed with an exception: {e}")
-
         retries += 1
         if retries < max_retries:
           sleep_time = backoff_factor * (2 ** (retries - 1))
@@ -147,90 +137,18 @@ class MAAProvider(IAttestationProvider):
             f"Request failed after all retries have been exhausted. Error: {e}"
           )
 
+  def attest_platform(self, evidence, runtime_data):
+    """
+    Verifies the Hardware Evidence provided by the Attester.
+    """
+    payload = self.create_payload(evidence, runtime_data)
+    return self._send_attestation_request(payload)
 
   def attest_guest(self, evidence):
     """
-    Verfies the Guest and Hardware Evidence provided by the Attester
+    Verifies the Guest and Hardware Evidence provided by the Attester.
     """
-
-    # Sends request to MAA using exponential backoff to handle
-    # any transient network issue
-    max_retries = 5
-    retries = 0
-    backoff_factor = 1
-    while retries < max_retries:
-      try:
-        self.log.info("Sending attestation request to provider...")
-
-        # Sends request to MAA for attesting the guest
-        response = requests.post(
-          self.endpoint,
-          data=json.dumps(evidence),
-          headers=DEFAULT_HEADERS
-        )
-        self.log.info(response.headers)
-
-        # Check the response from the server
-        if response.status_code == 200:
-          self.log.info("Received token from attestation provider")
-          response_json = json.loads(response.text)
-          encoded_token = response_json['token']
-
-          return encoded_token
-        elif response.status_code == 429: # Too Many Requests
-          self.log.warning(
-            f"Too many requests, error: {response.text}"
-          )
-
-          retries += 1
-          if retries < max_retries:
-            headers = response.headers
-            retry_after = headers.get('Retry-After')
-            sleep_time = int((retry_after))
-
-            # check if MAA has provided a retry after time in the response header
-            if retry_after:
-              self.log.info(f"Retrying in {retry_after} seconds...")
-              time.sleep(sleep_time)
-          else:
-            raise AttestationProviderException(
-              f"Unexpected status code: {response.status_code}, error: {response.text}"
-            )
-        elif response.status_code == 400:
-          self.log.error(
-            f"Failed to verify evidence due to invalid collateral, error: {response.text}"
-          )
-
-          return None
-        else:
-          self.log.error(
-            f"Failed to verify evidence, status code: {response.status_code}, error: {response.text}"
-          )
-
-          retries += 1
-          if retries < max_retries:
-            sleep_time = backoff_factor * (2 ** (retries - 1))
-            self.log.info(f"Retrying in {sleep_time} seconds...")
-            time.sleep(sleep_time)
-          else:
-            raise AttestationProviderException(
-              f"Unexpected status code: {response.status_code}, error: {response.text}"
-            )
-      except RequestException as e:
-        self.log.error(f"Request failed with an exception: {e}")
-
-        retries += 1
-        if retries < max_retries:
-          sleep_time = backoff_factor * (2 ** (retries - 1))
-          self.log.info(f"Retrying in {sleep_time} seconds...")
-          time.sleep(sleep_time)
-        else:
-          self.log.error(
-            f"Request failed after all retries have been exhausted. Error: {e}"
-          )
-          raise AttestationProviderException(
-            f"Request failed after all retries have been exhausted. Error: {e}"
-          )
+    return self._send_attestation_request(evidence)
 
 
   def print_snp_platform_claims(self, encoded_token):


### PR DESCRIPTION
Fixes the retry logic when the server does not respond with `Retry-After` in the response headers. This should avoid non-trivial waits.

Tests:
- [X] Tested in SNP
- [X] Tested in TDX

Unit Tests Logs:
```
collected 17 items                                                                                                                                                                                                                                                                        

cvm-attestation/tests/test_AttestationProvider.py::test_invalid_endpoint_provided PASSED                                                                                                                                                                                            [  5%]
cvm-attestation/tests/test_AttestationProvider.py::test_maa_provider_invalid_isolation_type PASSED                                                                                                                                                                                  [ 11%]
cvm-attestation/tests/test_AttestationProvider.py::test_create_payload_tdx PASSED                                                                                                                                                                                                   [ 17%]
cvm-attestation/tests/test_AttestationProvider.py::test_create_payload_sev_snp PASSED                                                                                                                                                                                               [ 23%]
cvm-attestation/tests/test_AttestationProvider.py::test_create_payload_fails_with_invalid_parameters PASSED                                                                                                                                                                         [ 29%]
cvm-attestation/tests/test_AttestationProvider.py::test_attest_guest_success PASSED                                                                                                                                                                                                 [ 35%]
cvm-attestation/tests/test_AttestationProvider.py::test_attest_guest_fails_with_http_401_after_retries PASSED                                                                                                                                                                       [ 41%]
cvm-attestation/tests/test_AttestationProvider.py::test_attest_guest_fails_with_exception_after_retries PASSED                                                                                                                                                                      [ 47%]
cvm-attestation/tests/test_AttestationProvider.py::test_attest_platform_success PASSED                                                                                                                                                                                              [ 52%]
cvm-attestation/tests/test_AttestationProvider.py::test_attest_platform_fails_with_http_401_after_retries PASSED                                                                                                                                                                    [ 58%]
cvm-attestation/tests/test_AttestationProvider.py::test_attest_platform_fails_with_exception_after_retries PASSED                                                                                                                                                                   [ 64%]
cvm-attestation/tests/test_AttestationProvider.py::test_attest_platform_returns_None_after_http_response_400 PASSED                                                                                                                                                                 [ 70%]
cvm-attestation/tests/test_AttestationProvider.py::test_attest_guest_returns_None_after_http_response_400 PASSED                                                                                                                                                                    [ 76%]
cvm-attestation/tests/test_AttestationProvider.py::test_attest_platform_retries_with_retry_after_header_until_max_retries PASSED                                                                                                                                                    [ 82%]
cvm-attestation/tests/test_AttestationProvider.py::test_attest_platform_succeeds_after_retries PASSED                                                                                                                                                                               [ 88%]
cvm-attestation/tests/test_AttestationProvider.py::test_attest_guest_succeeds_after_retries PASSED                                                                                                                                                                                  [ 94%]
cvm-attestation/tests/test_AttestationProvider.py::test_should_try_backoff_when_retry_after_not_present PASSED                                                                                                                                                                      [100%]

=================================================================================================================================== 17 passed in 0.31s ====================================================================================================================================
```