### PR TITLE
Fixing inconsistency with tdx and snp get_hardware_evidence

### DIFF
--- a/cvm-attestation/AttestationClient.py
+++ b/cvm-attestation/AttestationClient.py
@@ -151,8 +151,6 @@ class AttestationClient():
       else:
         raise UnsupportedReportTypeException(f"Unsupported report type: {report_type}")
 
-      evidence = HardwareEvidence(report_type, hw_report, runtime_data)
-      print('evidence: ', evidence)
       return HardwareEvidence(report_type, hw_report, runtime_data)
     except Exception as e:
       self.log.error(f"Error while reading hardware report. Exception {e}")

--- a/cvm-attestation/AttestationClient.py
+++ b/cvm-attestation/AttestationClient.py
@@ -140,15 +140,14 @@ class AttestationClient():
       if report_type == 'snp' and isolation_type == IsolationType.SEV_SNP:
         self.log_snp_report(hw_report)
       elif report_type == 'tdx' and isolation_type == IsolationType.TDX:
-        # self.log.info("Fetching td quote...")
+        self.log.info("Fetching td quote...")
         imds_client = ImdsClient(self.log)
         encoded_report = Encoder.base64url_encode(hw_report)
         encoded_hw_evidence = imds_client.get_td_quote(encoded_report)
         hw_report = Encoder.base64url_decode(encoded_hw_evidence)
-        print(hw_report, report_type, runtime_data)
-        # self.log.info("Finished fetching td quote")
+        self.log.info("Finished fetching td quote")
 
-        # self.log.info("Hardware report parsing for TDX not supported yet")
+        self.log.info("Hardware report parsing for TDX not supported yet")
       else:
         raise UnsupportedReportTypeException(f"Unsupported report type: {report_type}")
 

--- a/cvm-attestation/AttestationClient.py
+++ b/cvm-attestation/AttestationClient.py
@@ -140,10 +140,20 @@ class AttestationClient():
       if report_type == 'snp' and isolation_type == IsolationType.SEV_SNP:
         self.log_snp_report(hw_report)
       elif report_type == 'tdx' and isolation_type == IsolationType.TDX:
-        self.log.info("Hardware report parsing for TDX not supported yet")
+        # self.log.info("Fetching td quote...")
+        imds_client = ImdsClient(self.log)
+        encoded_report = Encoder.base64url_encode(hw_report)
+        encoded_hw_evidence = imds_client.get_td_quote(encoded_report)
+        hw_report = Encoder.base64url_decode(encoded_hw_evidence)
+        print(hw_report, report_type, runtime_data)
+        # self.log.info("Finished fetching td quote")
+
+        # self.log.info("Hardware report parsing for TDX not supported yet")
       else:
         raise UnsupportedReportTypeException(f"Unsupported report type: {report_type}")
 
+      evidence = HardwareEvidence(report_type, hw_report, runtime_data)
+      print('evidence: ', evidence)
       return HardwareEvidence(report_type, hw_report, runtime_data)
     except Exception as e:
       self.log.error(f"Error while reading hardware report. Exception {e}")

--- a/cvm-attestation/install.ps1
+++ b/cvm-attestation/install.ps1
@@ -1,48 +1,55 @@
 function Install-Chocolatey {
     Write-Output "Starting Install-Chocolatey..."
-
     $env:chocolateyVersion = '1.4.0'
     [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
-    Set-ExecutionPolicy Bypass -Scope Process -Force; Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))
-
-    Write-Output "Starting Install-Chocolatey...Done"
+    Set-ExecutionPolicy Bypass -Scope Process -Force
+    Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))
+    Write-Output "Install-Chocolatey...Done"
 }
 
 function Install-Python {
     Write-Output "Starting Install-Python..."
-
     choco install -y python --version 3.10.2
 
-    # Define the path you want to append
     $pythonPath = "C:\Python310"
-
-    # Append the new path to the existing PATH variable
     $env:PATH += ";$pythonPath"
 
     python.exe -m pip install --upgrade pip
     python.exe -m pip install --upgrade setuptools
-    python.exe -m pip install setuptools_scm
+    python.exe -m pip install setuptools_scm build
+
     python.exe -m pip install -r .\requirements.txt
 
     git submodule update --init --recursive
-
-    Write-Output "Starting Install-Python...Done"
+    Write-Output "Install-Python...Done"
 }
 
+function Build-And-Install {
+    Write-Output "Building and Installing..."
+    
+    # Build the project
+    python.exe -m build
+
+    # Install the built wheel
+    $wheel = Get-ChildItem -Path dist\*.whl | Select-Object -First 1
+    if ($wheel) {
+        pip install $wheel.FullName
+    } else {
+        Write-Error "Build failed: No .whl file found in dist/"
+        exit 1
+    }
+
+    # Update PATH for attest CLI
+    $attestPath = "C:\Python310\Scripts"
+    $env:PATH += ";$attestPath"
+
+    Write-Output "Building and Installing...Done"
+}
 
 function run {
     Install-Chocolatey
     Install-Python
-
-    # Install attest cli
-    python.exe  setup.py install
-
-     # Define the path you want to append
-    $attestPath = "C:\Python310\Scripts"
-
-    # Append the new path to the existing PATH variable
-    $env:PATH += ";$attestPath"
-
+    Build-And-Install
 }
 
 if ((Resolve-Path -Path $MyInvocation.InvocationName).ProviderPath -eq $MyInvocation.MyCommand.Path) {

--- a/cvm-attestation/install.ps1
+++ b/cvm-attestation/install.ps1
@@ -33,7 +33,7 @@ function Build-And-Install {
     # Install the built wheel
     $wheel = Get-ChildItem -Path dist\*.whl | Select-Object -First 1
     if ($wheel) {
-        pip install $wheel.FullName
+        python.exe -m pip install $wheel.FullName
     } else {
         Write-Error "Build failed: No .whl file found in dist/"
         exit 1

--- a/cvm-attestation/read_report.py
+++ b/cvm-attestation/read_report.py
@@ -70,13 +70,8 @@ def handle_hardware_report(report_type, output_path, attestation_client):
 
     logger.info("Got attestation report successfully!")
   elif report_type == 'td_quote':
-    imds_client = ImdsClient(logger)
-    hw_report = evidence.hardware_report
-    encoded_hw_report = Encoder.base64url_encode(hw_report)
-    encoded_hw_evidence = imds_client.get_td_quote(encoded_hw_report)
-    td_quote = Encoder.base64url_decode(encoded_hw_evidence)
     try:
-      deserialized_td_quote = deserialize_td_quotev4(td_quote)
+      deserialized_td_quote = deserialize_td_quotev4(evidence.hardware_report)
       print_td_quotev4(deserialized_td_quote)
       
     except UnicodeDecodeError:


### PR DESCRIPTION
PR to fix failing Windows install script due to setup.py deprecation.

- [X] Tested on Windows Server 2025
- [X] Unit test

Issue:
``` log
C:\Python310\lib\site-packages\setuptools\_distutils\cmd.py:90: SetuptoolsDeprecationWarning: setup.py install is deprecated.
!!

        ********************************************************************************
        Please avoid running `setup.py directly.
        Instead, use pypa/build, pypa/installer or other
        standards-based tools.

        See https://blog.ganssle.io/articles/2021/10/setup-py-deprecated.html for details.
        ********************************************************************************

!!
  self.initialize_options()
```

Unit test logs:
```
plugins: anyio-4.8.0, mock-3.11.1
collected 63 items                                                                               

cvm-attestation/test_AttestationClient.py .....                                            [  7%]
cvm-attestation/test_attest.py ......                                                      [ 17%]
cvm-attestation/test_snp.py ......                                                         [ 26%]
cvm-attestation/tests/test_AttestationProvider.py .................                        [ 53%]
cvm-attestation/tests/test_EndpointSelector.py ..........                                  [ 69%]
cvm-attestation/tests/test_ImdsClient.py ............                                      [ 88%]
cvm-attestation/tests/test_Isolation.py ....                                               [ 95%]
cvm-attestation/tests/test_ReportParser.py ..                                              [ 98%]
cvm-attestation/tests/test_measurements.py s                                               [100%]

================================= 62 passed, 1 skipped in 1.22s ==================================
```
