### PR TITLE
[Bugfix] Add python to beginning of the path in installation script

### DIFF
--- a/cvm-attestation/install.ps1
+++ b/cvm-attestation/install.ps1
@@ -12,7 +12,7 @@ function Install-Python {
     choco install -y python --version 3.10.2
 
     $pythonPath = "C:\Python310"
-    $env:PATH += ";$pythonPath"
+    $env:PATH = "$pythonPath;" + $env:PATH
 
     python.exe -m pip install --upgrade pip
     python.exe -m pip install --upgrade setuptools
@@ -41,7 +41,7 @@ function Build-And-Install {
 
     # Update PATH for attest CLI
     $attestPath = "C:\Python310\Scripts"
-    $env:PATH += ";$attestPath"
+    $env:PATH = "$attestPath;" + $env:PATH
 
     Write-Output "Building and Installing...Done"
 }


### PR DESCRIPTION
In some versions of windows, there exists a python.exe within `C:\Users\<username>\AppData\Local\Microsoft\WindowsApps` that does not actually run python, but opens the windows store. Any calls to python.exe use the first valid path in `$env:PATH`, leading to instances where the install script will sometimes try to open the windows store. This PR puts `C:\Python310` at the beginning of the path, making any version of windows use the valid python.exe by default.