### PR TITLE
Log OS provisioning claims if they exist

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -50,6 +50,7 @@ jobs:
 
   Create-Release:
     runs-on: ubuntu-22.04
+    if: github.event_name != 'pull_request_target'  # Skip on PR target events
     needs: [Build-On-Windows, Build-On-Linux]
     steps:
       - name: Check out repository code

--- a/cvm-attestation/src/AttestationProvider.py
+++ b/cvm-attestation/src/AttestationProvider.py
@@ -224,6 +224,8 @@ class MAAProvider(IAttestationProvider):
         self.log.info(f"SNP TEE SVN: {claims['x-ms-isolation-tee']['x-ms-sevsnpvm-tee-svn']}")
         self.log.info(f"Report Data: {claims['x-ms-isolation-tee']['x-ms-sevsnpvm-reportdata']}")
         self.log.info(f"User Claims Digest: {claims['x-ms-isolation-tee']['x-ms-runtime']['user-data']}")
+        if claims['x-ms-azurevm-os-provisioning']:
+          self.log.info(f"OS provisioning claims: {claims['x-ms-azurevm-os-provisioning']}")
         self.log.info("Attested Guest Successfully!!")
     except Exception as e:
       raise AttestationProviderException(f'Exception while decoding jwt. Exception: {e}')
@@ -243,6 +245,8 @@ class MAAProvider(IAttestationProvider):
         self.log.info(f"TEE TCB SVN: {claims['x-ms-isolation-tee']['tdx_tee_tcb_svn']}")
         self.log.info(f"Report Data: {claims['x-ms-isolation-tee']['tdx_report_data']}")
         self.log.info(f"User Claims Digest: {claims['x-ms-isolation-tee']['x-ms-runtime']['user-data']}")
+        if claims['x-ms-azurevm-os-provisioning']:
+          self.log.info(f"OS provisioning claims: {claims['x-ms-azurevm-os-provisioning']}")
         self.log.info("Attested Guest Successfully!!")
     except Exception as e:
       raise AttestationProviderException(f'Exception while decoding jwt. Exception: {e}')


### PR DESCRIPTION
### Summary
Add support for logging OS provisioning claims. On both Linux and Windows, MAA surfaces disk integrity claims under `x-ms-azurevm-os-provisioning`.

Sample output on SNP CVM with Windows ReFS:
```
PS C:\Users\ACCDev\cvm-attestation-tools\cvm-attestation> attest  --c .\config_snp.json --t Guest
TSS.Py::__INIT__.PY invoked
2025-06-10 17:15:29,271 - attest - INFO - Attestation started...
...
2025-06-10 17:15:33,080 - print_snp_guest_claims - INFO - Claims:
2025-06-10 17:15:33,080 - print_snp_guest_claims - INFO - Attestation Type: sevsnpvm
2025-06-10 17:15:33,080 - print_snp_guest_claims - INFO - Status: azure-compliant-cvm
2025-06-10 17:15:33,080 - print_snp_guest_claims - INFO - SNP Bootloader SVN: 4
2025-06-10 17:15:33,080 - print_snp_guest_claims - INFO - SNP Guest SVN: 9
2025-06-10 17:15:33,080 - print_snp_guest_claims - INFO - SNP Microcode SVN: 219
2025-06-10 17:15:33,081 - print_snp_guest_claims - INFO - SNP Firmware SVN: 24
2025-06-10 17:15:33,081 - print_snp_guest_claims - INFO - SNP TEE SVN: 0
2025-06-10 17:15:33,081 - print_snp_guest_claims - INFO - Report Data: 9a544e36f47aa872f11650ca819cbfe97b9acccc970e9bd075e98c21ea21fb830000000000000000000000000000000000000000000000000000000000000000
2025-06-10 17:15:33,081 - print_snp_guest_claims - INFO - User Claims Digest: 4BD03DC197F0BF46D4D40480925401BE4FC55D6EFD05095D867EBA038F4432BB0F2EA7F0D8AAE01811044038FE61ED662866C7E67A5482CD94DB0069B67717AE
2025-06-10 17:15:33,081 - print_snp_guest_claims - INFO - OS provisioning claims: {'os-image-identity': {'eventVersion': '1', 'frozenChecksum': '5161ebf8c9f8fc7e54fe39eee66de13aa17f2173fdd38509a5be30522b4e265c', 'rollbackCheckSuccess': True}}
2025-06-10 17:15:33,081 - print_snp_guest_claims - INFO - Attested Guest Successfully!!
```

