### PR TITLE
Fix endpoint file path retrieval in get_endpoint function

### DIFF
--- a/cvm-attestation/attest.py
+++ b/cvm-attestation/attest.py
@@ -58,12 +58,26 @@ def get_endpoint(logger, isolation_type: IsolationType, attestation_type: str):
   
   region = region.replace(" ", "").lower()
 
-  current_dir = os.path.dirname(os.path.abspath(sys.argv[0]))
   if "usgov" in region:
     filename = 'attestation_uri_table_usgov.json'
   else:
     filename = 'attestation_uri_table.json'
-  endpoint_file_path = os.path.join(current_dir, filename)
+
+  search_dirs = [
+    os.path.dirname(os.path.abspath(__file__)),
+    os.path.dirname(os.path.abspath(sys.argv[0])),
+    os.getcwd()
+  ]
+
+  endpoint_file_path = None
+  for d in search_dirs:
+    candidate = os.path.join(d, filename)
+    if os.path.isfile(candidate):
+      endpoint_file_path = candidate
+      break
+
+  if endpoint_file_path is None:
+    raise AttestException(f"Could not find {filename} in any of: {search_dirs}")
 
   endpoint_selector = EndpointSelector(endpoint_file_path, logger)
   return endpoint_selector.get_attestation_endpoint(isolation_type, attestation_type, region)


### PR DESCRIPTION
This pull request improves the robustness of the endpoint file lookup logic in the `get_endpoint` function. The function now searches multiple directories for the attestation URI table file, ensuring it can be found regardless of the script's execution context.

**File lookup improvements:**

* Updated `get_endpoint` in `attest.py` to search for the attestation URI table file (`attestation_uri_table.json` or `attestation_uri_table_usgov.json`) in multiple directories: the directory of the current file, the directory of the script being executed, and the current working directory. If the file is not found, an exception is raised.