### PR TITLE
fix(attestation_provider): require HTTPS for MAA/ITA endpoints

### DIFF
--- a/cvm-attestation/src/attestation_provider.py
+++ b/cvm-attestation/src/attestation_provider.py
@@ -50,11 +50,12 @@ class MAAProvider(IAttestationProvider):
         f"Unsupported isolation type: {isolation}. Supported types: {list(IsolationType)}"
       )
 
-     # Validate the endpoint
+     # Validate the endpoint - HTTPS is required so attestation tokens are
+     # delivered over an authenticated, encrypted channel.
     parsed_endpoint = urlparse(endpoint)
-    if not parsed_endpoint.scheme or not parsed_endpoint.netloc:
+    if parsed_endpoint.scheme != 'https' or not parsed_endpoint.netloc:
       raise ValueError(
-        f"Invalid endpoint: {endpoint}. Endpoint must be a valid URL."
+        f"Invalid endpoint: {endpoint}. Endpoint must be a valid HTTPS URL."
       )
 
     self.log = logger
@@ -328,10 +329,11 @@ class ITAProvider(IAttestationProvider):
     if not isinstance(isolation, IsolationType):
       raise ValueError(f"Unsupported isolation type: {isolation}. Supported types: {list(IsolationType)}")
 
-      # Validate the endpoint
+    # Validate the endpoint - HTTPS is required so attestation tokens and
+    # the api_key are sent over an authenticated, encrypted channel.
     parsed_endpoint = urlparse(endpoint)
-    if not parsed_endpoint.scheme or not parsed_endpoint.netloc:
-      raise ValueError(f"Invalid endpoint: {endpoint}. Endpoint must be a valid URL.")
+    if parsed_endpoint.scheme != 'https' or not parsed_endpoint.netloc:
+      raise ValueError(f"Invalid endpoint: {endpoint}. Endpoint must be a valid HTTPS URL.")
 
     self.log = logger
     self.isolation = isolation

--- a/cvm-attestation/tests/test_attestation_provider.py
+++ b/cvm-attestation/tests/test_attestation_provider.py
@@ -22,7 +22,7 @@ def maa_provider(mocker):
   mocker.patch.object(logger, 'info')
   mocker.patch.object(logger, 'error')
 
-  endpoint = "http://someendpoint.com/api"
+  endpoint = "https://someendpoint.com/api"
   return MAAProvider(logger, IsolationType.UNDEFINED, endpoint)
 
 
@@ -35,10 +35,20 @@ def test_invalid_endpoint_provided():
   assert "Invalid endpoint" in str(excinfo.value)
 
 
+def test_http_endpoint_is_rejected():
+  # HTTPS is required so attestation tokens are not delivered in cleartext.
+  isolation = IsolationType.TDX
+  http_endpoint = "http://someendpoint.com/api"
+
+  with pytest.raises(ValueError) as excinfo:
+      MAAProvider(default_logger, isolation, http_endpoint)
+  assert "HTTPS" in str(excinfo.value)
+
+
 def test_maa_provider_invalid_isolation_type():
   
   invalid_isolation = "invalid_type"
-  endpoint = "http://someendpoint.com/api"
+  endpoint = "https://someendpoint.com/api"
 
   with pytest.raises(ValueError) as excinfo:
       MAAProvider(default_logger, invalid_isolation, endpoint)


### PR DESCRIPTION
Tighten endpoint validation in MAAProvider and ITAProvider to reject any
URL whose scheme is not 'https'. Previously the check only required a
non-empty scheme, which silently accepted plain-HTTP endpoints loaded
from attestation_uri_table.json (or attestation_uri_table_usgov.json),
allowing attestation tokens to be delivered in cleartext if a malicious
or misconfigured table file pointed at an http:// URL.